### PR TITLE
feat: P1 quick wins — sanitization, forget/episodes tools, multi-group search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Changelog
 
+## [0.7.0] — 2026-03-15
+
+### Added
+
+- **`graphiti_forget` tool**: Delete facts or episodes from the knowledge graph.
+  Supports direct deletion by UUID (`type: "fact" | "episode"`) or search-then-delete
+  by query (auto-deletes single matches, lists candidates for multiple matches).
+  New client methods: `deleteEdge(uuid)` and `deleteEpisode(uuid)`.
+
+- **`graphiti_episodes` tool**: List recent ingestion records as an agent tool.
+  Accepts `limit` (max 50) and optional `sessionKey` filter. Reuses the same
+  session-key filtering logic as the CLI `episodes` command.
+
+- **Multi-group search**: `graphiti_search` tool and `client.search()` now accept
+  an optional `groupIds` parameter to search across multiple graph groups in a
+  single call. Falls back to the configured `groupId` when omitted.
+
+- **Input sanitization**: New `sanitizeForCapture()` function strips plugin-injected
+  metadata before graph ingestion, preventing feedback loops where recalled context
+  (`<graphiti-context>` blocks), conversation metadata JSON, `[Subagent Context]`
+  lines, and timestamps are re-ingested as new knowledge. Applied at all 4
+  ContextEngine ingestion points (`ingest`, `ingestBatch`, `afterTurn`, `compact`).
+
+- **Temporal info in CLI search**: `openclaw graphiti search` now displays
+  `valid_at` and `invalid_at` alongside each fact.
+
+### Changed
+
+- **`recallMaxFacts` default raised from 1 to 10**: Aligns `openclaw.plugin.json`
+  and the `index.ts` fallback with the ContextEngine default (which already used
+  10). When auto-recall is enabled, the agent now receives a useful amount of
+  context by default.
+
 ## [0.6.2] — 2026-03-12
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## [Unreleased]
+## [0.7.0-beta.1] — 2026-03-22
+
+> Beta release for P1 quick wins.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@
 
 - **`graphiti_forget` tool**: Delete facts or episodes from the knowledge graph.
   Supports direct deletion by UUID (`type: "fact" | "episode"`) or search-then-delete
-  by query (auto-deletes single matches, lists candidates for multiple matches).
+  by query. Note: query-based search currently supports facts only — to delete an
+  episode, use its UUID directly. Auto-deletes single fact matches and lists
+  candidates for multiple matches. Includes UUID format validation for defense-in-depth.
   New client methods: `deleteEdge(uuid)` and `deleteEpisode(uuid)`.
 
 - **`graphiti_episodes` tool**: List recent ingestion records as an agent tool.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.7.0] — 2026-03-15
+## [Unreleased]
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Temporal knowledge graph plugin for [OpenClaw](https://github.com/openclaw/openc
 
 ## What it does
 
-- **Knowledge graph tools**: `graphiti_search` and `graphiti_ingest` available as agent tools for on-demand entity/relationship queries and manual ingestion
+- **Knowledge graph tools**: `graphiti_search`, `graphiti_ingest`, `graphiti_forget`, and `graphiti_episodes` available as agent tools for on-demand entity/relationship queries, manual ingestion, fact deletion, and episode browsing
 - **Auto-capture**: Automatically ingests conversation content into the knowledge graph (per-turn in ContextEngine mode, on compaction/reset in hooks mode) for entity/relationship extraction (async, via Graphiti's LLM pipeline)
 - **Auto-index**: Automatically creates index episodes in Graphiti when files are written to `memory/`, bridging file-based memory with the knowledge graph
 - **Auto-recall**: Optionally injects relevant facts before each turn — off by default, see [Auto-recall vs on-demand search](#auto-recall-vs-on-demand-search)
@@ -81,6 +81,8 @@ knowledge graph, operating independently on different data.
 | "What's the relationship between X and Y?" | `graphiti_search` |
 | "What was the history of project X?" | `graphiti_search` (temporal queries) |
 | "Remember this fact long-term" | `graphiti_ingest` |
+| "Forget this outdated fact" | `graphiti_forget` |
+| "What was captured recently?" | `graphiti_episodes` |
 
 ## Configuration
 
@@ -93,7 +95,7 @@ knowledge graph, operating independently on different data.
 | `autoCapture` | boolean | `true` | Automatically ingest conversation content into the graph |
 | `autoIndex` | boolean | `true` | Create index episodes when files are written to `memory/` |
 | `autoIndexExtensions` | string[] | `[".md", ".txt"]` | File extensions to index (non-matching files are skipped) |
-| `recallMaxFacts` | number | `1` | Max facts to inject per turn when auto-recall is on |
+| `recallMaxFacts` | number | `10` | Max facts to inject per turn when auto-recall is on |
 | `minPromptLength` | number | `10` | Min prompt length to trigger auto-recall |
 | `debug` | boolean | `true` | Enable structured debug log file |
 | `logFile` | string | `~/.openclaw/logs/graphiti-plugin.log` | Custom debug log file path |

--- a/client.ts
+++ b/client.ts
@@ -67,6 +67,28 @@ export class GraphitiClient {
     }
   }
 
+  private async fetchDelete(path: string): Promise<void> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 15_000);
+    const start = Date.now();
+
+    try {
+      const res = await fetch(`${this.url}${path}`, {
+        method: "DELETE",
+        headers: this.headers(),
+        signal: controller.signal,
+      });
+
+      if (!res.ok) {
+        const text = await res.text().catch(() => "");
+        this.debugLog.log(path.slice(1), { status: res.status, group: this.groupId, error: "HTTP error", ms: Date.now() - start });
+        throw new Error(`Graphiti DELETE ${path} returned ${res.status}: ${text}`);
+      }
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
   /**
    * Search for facts by query.
    */
@@ -179,5 +201,23 @@ export class GraphitiClient {
       this.debugLog.log("episodes", { group: this.groupId, error: "unreachable", ms: Date.now() - start });
       return [];
     }
+  }
+
+  /**
+   * Delete a fact/edge by UUID.
+   */
+  async deleteEdge(uuid: string): Promise<void> {
+    const start = Date.now();
+    await this.fetchDelete(`/entity-edge/${uuid}`);
+    this.debugLog.log("deleteEdge", { status: 200, group: this.groupId, uuid, ms: Date.now() - start });
+  }
+
+  /**
+   * Delete an episode by UUID.
+   */
+  async deleteEpisode(uuid: string): Promise<void> {
+    const start = Date.now();
+    await this.fetchDelete(`/episode/${uuid}`);
+    this.debugLog.log("deleteEpisode", { status: 200, group: this.groupId, uuid, ms: Date.now() - start });
   }
 }

--- a/client.ts
+++ b/client.ts
@@ -14,6 +14,19 @@ export interface GraphitiFact {
   expired_at: string | null;
 }
 
+export interface GraphitiEpisode {
+  uuid: string;
+  name?: string;
+  group_id?: string;
+  labels?: string[];
+  created_at?: string;
+  source?: string;
+  source_description?: string;
+  content?: string;
+  valid_at?: string;
+  entity_edges?: string[];
+}
+
 export interface GraphitiMessage {
   content: string;
   role_type: "user" | "assistant" | "system";
@@ -84,6 +97,9 @@ export class GraphitiClient {
         this.debugLog.log(path.slice(1), { status: res.status, group: this.groupId, error: "HTTP error", ms: Date.now() - start });
         throw new Error(`Graphiti DELETE ${path} returned ${res.status}: ${text}`);
       }
+
+      // Consume the response body to allow connection reuse (HTTP keep-alive)
+      await res.text().catch(() => {});
     } finally {
       clearTimeout(timeout);
     }
@@ -177,7 +193,7 @@ export class GraphitiClient {
    *
    * Note: The server returns a bare JSON array, not a wrapped object.
    */
-  async episodes(lastN = 10): Promise<any[]> {
+  async episodes(lastN = 10): Promise<GraphitiEpisode[]> {
     const start = Date.now();
     try {
       const controller = new AbortController();

--- a/client.ts
+++ b/client.ts
@@ -92,11 +92,11 @@ export class GraphitiClient {
   /**
    * Search for facts by query.
    */
-  async search(query: string, maxFacts = 10): Promise<GraphitiFact[]> {
+  async search(query: string, maxFacts = 10, groupIds?: string[]): Promise<GraphitiFact[]> {
     const start = Date.now();
     const data = await this.fetch("/search", {
       query,
-      group_ids: [this.groupId],
+      group_ids: groupIds ?? [this.groupId],
       max_facts: maxFacts,
     });
     const facts = data.facts ?? [];

--- a/context-engine.ts
+++ b/context-engine.ts
@@ -484,14 +484,14 @@ export class GraphitiContextEngine {
 
       let episode: string;
       if (hasSummary) {
-        episode = params.summary!.slice(0, 12000);
+        episode = sanitizeForCapture(params.summary!).slice(0, 12000);
       } else {
         const texts = extractTextsFromMessages(params.messages!);
         if (texts.length === 0) {
           this.debugLog.log("ce-subagentEnded", { child: params.childSessionKey, action: "no_content" });
           return;
         }
-        episode = texts.join("\n\n").slice(0, 12000);
+        episode = sanitizeForCapture(texts.join("\n\n")).slice(0, 12000);
       }
 
       await this.client.ingest([{

--- a/context-engine.ts
+++ b/context-engine.ts
@@ -203,6 +203,7 @@ export class GraphitiContextEngine {
         return passThrough;
       }
 
+      // TODO: /get-memory only accepts single group_id — multi-group recall needs server changes
       const maxFacts = this.cfg.recallMaxFacts ?? 10;
       const facts = await this.client.getMemory(graphitiMessages, maxFacts);
 

--- a/context-engine.ts
+++ b/context-engine.ts
@@ -9,7 +9,7 @@
 import { createRequire } from "node:module";
 import type { GraphitiClient, GraphitiMessage } from "./client.js";
 import type { DebugLog } from "./debug-log.js";
-import { buildEpisodeName, buildProvenance, extractTextContent, extractTextsFromMessages, formatFactsAsContext } from "./shared.js";
+import { buildEpisodeName, buildProvenance, extractTextContent, extractTextsFromMessages, formatFactsAsContext, sanitizeForCapture } from "./shared.js";
 
 const _require = createRequire(import.meta.url);
 const PLUGIN_VERSION: string = (_require("./package.json") as any).version;
@@ -132,9 +132,10 @@ export class GraphitiContextEngine {
       return { ingested: false };
     }
 
-    const text = extractTextContent(content);
-    if (!text) {
-      this.debugLog.log("ce-ingest", { skipped: true, reason: "short_content" });
+    const rawText = extractTextContent(content);
+    const text = rawText ? sanitizeForCapture(rawText) : null;
+    if (!text || text.length < 20) {
+      this.debugLog.log("ce-ingest", { skipped: true, reason: text ? "sanitized_short" : "short_content" });
       return { ingested: false };
     }
 
@@ -264,7 +265,7 @@ export class GraphitiContextEngine {
           return { ok: true, compacted: true };
         }
 
-        const episode = texts.join("\n\n").slice(0, 12000);
+        const episode = sanitizeForCapture(texts.join("\n\n")).slice(0, 12000);
         await this.client.ingest([{
           content: episode,
           role_type: "user",
@@ -315,7 +316,8 @@ export class GraphitiContextEngine {
       return { ingestedCount: 0 };
     }
 
-    const texts = extractTextsFromMessages(params.messages);
+    const rawTexts = extractTextsFromMessages(params.messages);
+    const texts = rawTexts.map(sanitizeForCapture).filter(t => t.length > 0);
     if (texts.length === 0) {
       this.debugLog.log("ce-ingestBatch", { skipped: true, reason: "no_content" });
       return { ingestedCount: 0 };
@@ -399,7 +401,11 @@ export class GraphitiContextEngine {
 
     try {
       const start = Date.now();
-      const joined = texts.join("\n\n");
+      const joined = sanitizeForCapture(texts.join("\n\n"));
+      if (!joined) {
+        this.debugLog.log("ce-afterTurn", { skipped: true, reason: "sanitized_empty" });
+        return;
+      }
       const episode = compactionOccurred
         ? joined.slice(-12000)   // sweep: keep tail (newest messages)
         : joined.slice(0, 12000);

--- a/index.ts
+++ b/index.ts
@@ -131,12 +131,15 @@ const graphitiPlugin = {
           limit: Type.Optional(
             Type.Number({ description: "Max results (default: 10)", minimum: 1, maximum: 50 })
           ),
+          groupIds: Type.Optional(
+            Type.Array(Type.String(), { description: "Search across specific group IDs (default: current group)" })
+          ),
         }),
         async execute(_toolCallId, params) {
-          const { query, limit = 10 } = params as { query: string; limit?: number };
+          const { query, limit = 10, groupIds } = params as { query: string; limit?: number; groupIds?: string[] };
 
           try {
-            const facts = await client.search(query, limit);
+            const facts = await client.search(query, limit, groupIds);
 
             if (facts.length === 0) {
               return {

--- a/index.ts
+++ b/index.ts
@@ -219,6 +219,89 @@ const graphitiPlugin = {
       { name: "graphiti_ingest" },
     );
 
+    api.registerTool(
+      {
+        name: "graphiti_forget",
+        label: "Graphiti Forget",
+        description:
+          "Delete a fact or episode from the knowledge graph. " +
+          "Search by query to find and remove, or delete directly by UUID.",
+        parameters: Type.Object({
+          query: Type.Optional(Type.String({ description: "Search query to find the fact/episode to delete" })),
+          uuid: Type.Optional(Type.String({ description: "Direct UUID of the fact/episode to delete" })),
+          type: Type.Optional(
+            Type.Union([Type.Literal("fact"), Type.Literal("episode")], {
+              description: "Type of entity to delete (default: fact)",
+              default: "fact",
+            })
+          ),
+        }),
+        async execute(_toolCallId, params) {
+          const { query, uuid, type = "fact" } = params as {
+            query?: string; uuid?: string; type?: "fact" | "episode";
+          };
+
+          if (!query && !uuid) {
+            return {
+              content: [{ type: "text", text: "Please provide either a query or uuid parameter." }],
+            };
+          }
+
+          try {
+            if (uuid) {
+              if (type === "episode") {
+                await client.deleteEpisode(uuid);
+              } else {
+                await client.deleteEdge(uuid);
+              }
+              return {
+                content: [{ type: "text", text: `Deleted ${type} ${uuid}.` }],
+                details: { deleted: true, uuid, type },
+              };
+            }
+
+            const facts = await client.search(query!, 10);
+            if (facts.length === 0) {
+              return {
+                content: [{ type: "text", text: `No matching facts found for "${query}".` }],
+                details: { deleted: false, reason: "no_matches" },
+              };
+            }
+
+            if (facts.length === 1) {
+              await client.deleteEdge(facts[0].uuid);
+              return {
+                content: [{
+                  type: "text",
+                  text: `Deleted fact: "${facts[0].name}: ${facts[0].fact}" (${facts[0].uuid}).`,
+                }],
+                details: { deleted: true, uuid: facts[0].uuid, type: "fact" },
+              };
+            }
+
+            const list = facts
+              .map((f, i) => `${i + 1}. [${f.uuid}] **${f.name}**: ${f.fact}`)
+              .join("\n");
+            return {
+              content: [{
+                type: "text",
+                text: `Found ${facts.length} matching facts. Please specify a UUID to delete:\n\n${list}`,
+              }],
+              details: { deleted: false, reason: "multiple_matches", count: facts.length },
+            };
+          } catch (err) {
+            return {
+              content: [{
+                type: "text",
+                text: `Graphiti forget failed: ${err instanceof Error ? err.message : String(err)}`,
+              }],
+            };
+          }
+        },
+      },
+      { name: "graphiti_forget" },
+    );
+
     // ========================================================================
     // ContextEngine registration (OpenClaw v2026.3.7+)
     // ========================================================================

--- a/index.ts
+++ b/index.ts
@@ -83,7 +83,7 @@ const graphitiPlugin = {
     const groupId = cfg.groupId ?? "core";
     const autoRecall = cfg.autoRecall === true;
     const autoCapture = cfg.autoCapture !== false;
-    const recallMaxFacts = cfg.recallMaxFacts ?? 1;
+    const recallMaxFacts = cfg.recallMaxFacts ?? 10;
     const minPromptLength = cfg.minPromptLength ?? 10;
     const apiKey = cfg.apiKey;
     const autoIndex = cfg.autoIndex !== false;

--- a/index.ts
+++ b/index.ts
@@ -248,11 +248,20 @@ const graphitiPlugin = {
           if (!query && !uuid) {
             return {
               content: [{ type: "text", text: "Please provide either a query or uuid parameter." }],
+              details: { deleted: false, reason: "missing_params" },
             };
           }
 
           try {
             if (uuid) {
+              // Validate UUID format before sending to the server (defense-in-depth for destructive endpoint)
+              const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+              if (!UUID_RE.test(uuid)) {
+                return {
+                  content: [{ type: "text", text: `Invalid UUID format: "${uuid}". Expected format: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx` }],
+                  details: { deleted: false, reason: "invalid_uuid", uuid },
+                };
+              }
               if (type === "episode") {
                 await client.deleteEpisode(uuid);
               } else {
@@ -386,6 +395,7 @@ const graphitiPlugin = {
           } catch (err) {
             return {
               content: [{ type: "text", text: `Graphiti episodes failed: ${err instanceof Error ? err.message : String(err)}` }],
+              details: { count: 0, reason: "error", error: err instanceof Error ? err.message : String(err) },
             };
           }
         },

--- a/index.ts
+++ b/index.ts
@@ -602,7 +602,11 @@ const graphitiPlugin = {
             try {
               const facts = await client.search(query, parseInt(opts.limit));
               if (facts.length === 0) { console.log("No facts found."); return; }
-              for (const f of facts) { console.log(`• ${f.name}: ${f.fact}`); }
+              for (const f of facts) {
+                const valid = f.valid_at ?? "ongoing";
+                const invalid = f.invalid_at ? ` \u2192 ${f.invalid_at}` : "";
+                console.log(`\u2022 ${f.name}: ${f.fact}  [${valid}${invalid}]`);
+              }
             } catch (err) {
               console.error(`Search failed: ${err instanceof Error ? err.message : String(err)}`);
               process.exitCode = 1;

--- a/index.ts
+++ b/index.ts
@@ -19,10 +19,10 @@ import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import { Type } from "@sinclair/typebox";
 import path from "node:path";
 import os from "node:os";
-import { GraphitiClient } from "./client.js";
+import { GraphitiClient, type GraphitiEpisode } from "./client.js";
 import { DebugLog, NOOP_LOG } from "./debug-log.js";
 import { extractMemoryPath, upsertIndexEpisode, scanMemoryFiles, readIndexState, writeIndexState, readMemoryFileMeta, buildIndexContent, indexEpisodeName, isIndexableFile, DEFAULT_INDEX_EXTENSIONS } from "./memory-index.js";
-import { buildProvenance, extractTextsFromMessages, buildEpisodeName, type SessionMeta } from "./shared.js";
+import { buildProvenance, extractTextsFromMessages, buildEpisodeName, sanitizeForCapture, type SessionMeta } from "./shared.js";
 import { GraphitiContextEngine } from "./context-engine.js";
 
 // Re-export public types from shared.ts for backwards compatibility
@@ -228,7 +228,8 @@ const graphitiPlugin = {
         label: "Graphiti Forget",
         description:
           "Delete a fact or episode from the knowledge graph. " +
-          "Search by query to find and remove, or delete directly by UUID.",
+          "Delete directly by UUID (supports both facts and episodes), or search by query to find and remove. " +
+          "Note: query-based search only supports facts — to delete an episode, use its UUID directly.",
         parameters: Type.Object({
           query: Type.Optional(Type.String({ description: "Search query to find the fact/episode to delete" })),
           uuid: Type.Optional(Type.String({ description: "Direct UUID of the fact/episode to delete" })),
@@ -260,6 +261,17 @@ const graphitiPlugin = {
               return {
                 content: [{ type: "text", text: `Deleted ${type} ${uuid}.` }],
                 details: { deleted: true, uuid, type },
+              };
+            }
+
+            // Query-based search only supports facts — episode-by-query is not yet implemented
+            if (type === "episode") {
+              return {
+                content: [{
+                  type: "text",
+                  text: `Query-based episode deletion is not supported. Use a UUID to delete an episode directly, or use graphiti_episodes to find the episode UUID first.`,
+                }],
+                details: { deleted: false, reason: "episode_query_not_supported" },
               };
             }
 
@@ -298,6 +310,7 @@ const graphitiPlugin = {
                 type: "text",
                 text: `Graphiti forget failed: ${err instanceof Error ? err.message : String(err)}`,
               }],
+              details: { deleted: false, reason: "error", error: err instanceof Error ? err.message : String(err) },
             };
           }
         },
@@ -311,7 +324,8 @@ const graphitiPlugin = {
         label: "Graphiti Episodes",
         description:
           "List recent episodes (ingestion records) from the knowledge graph. " +
-          "Useful for understanding what has been captured and when.",
+          "Useful for understanding what has been captured and when. " +
+          "When filtering by sessionKey, more episodes are fetched server-side to compensate for client-side filtering.",
         parameters: Type.Object({
           limit: Type.Optional(
             Type.Number({ description: "Max episodes to return (default: 10, max: 50)", minimum: 1, maximum: 50 })
@@ -324,10 +338,13 @@ const graphitiPlugin = {
           const { limit = 10, sessionKey } = params as { limit?: number; sessionKey?: string };
 
           try {
-            let eps = await client.episodes(limit);
+            // When filtering by sessionKey, fetch more episodes server-side to
+            // compensate for the client-side filter reducing the result set.
+            const fetchLimit = sessionKey ? Math.min(limit * 5, 250) : limit;
+            let eps = await client.episodes(fetchLimit);
 
             if (sessionKey) {
-              eps = eps.filter((ep: any) => {
+              eps = eps.filter((ep: GraphitiEpisode) => {
                 try {
                   const prov = JSON.parse(ep.source_description ?? "");
                   return prov.session_key === sessionKey;
@@ -335,7 +352,7 @@ const graphitiPlugin = {
                   return ep.source_description?.includes(`session=${sessionKey}`) ||
                     ep.name?.includes(sessionKey);
                 }
-              });
+              }).slice(0, limit);
             }
 
             if (eps.length === 0) {
@@ -345,7 +362,7 @@ const graphitiPlugin = {
               };
             }
 
-            const lines = eps.map((ep: any, i: number) => {
+            const lines = eps.map((ep: GraphitiEpisode, i: number) => {
               let desc = "";
               try {
                 const prov = JSON.parse(ep.source_description ?? "");
@@ -456,7 +473,7 @@ const graphitiPlugin = {
           const texts = extractTextsFromMessages(messages);
           if (texts.length < 2) return;
 
-          const episode = texts.join("\n\n").slice(0, 12000);
+          const episode = sanitizeForCapture(texts.join("\n\n")).slice(0, 12000);
 
           await client.ingest([{
             content: episode,
@@ -499,7 +516,7 @@ const graphitiPlugin = {
           if (texts.length < 2) return;
 
           // Take a sample — last 20 exchanges max
-          const sample = texts.slice(-20).join("\n\n");
+          const sample = sanitizeForCapture(texts.slice(-20).join("\n\n"));
 
           await client.ingest([{
             content: sample.slice(0, 12000),
@@ -623,7 +640,7 @@ const graphitiPlugin = {
             // If your session has many episodes and --limit is low, increase
             // --limit or use --json to retrieve all and filter externally.
             if (opts.sessionKey) {
-              eps = eps.filter((ep: any) => {
+              eps = eps.filter((ep: GraphitiEpisode) => {
                 try {
                   const prov = JSON.parse(ep.source_description ?? "");
                   return prov.session_key === opts.sessionKey;

--- a/index.ts
+++ b/index.ts
@@ -302,6 +302,77 @@ const graphitiPlugin = {
       { name: "graphiti_forget" },
     );
 
+    api.registerTool(
+      {
+        name: "graphiti_episodes",
+        label: "Graphiti Episodes",
+        description:
+          "List recent episodes (ingestion records) from the knowledge graph. " +
+          "Useful for understanding what has been captured and when.",
+        parameters: Type.Object({
+          limit: Type.Optional(
+            Type.Number({ description: "Max episodes to return (default: 10, max: 50)", minimum: 1, maximum: 50 })
+          ),
+          sessionKey: Type.Optional(
+            Type.String({ description: "Filter episodes by session key" })
+          ),
+        }),
+        async execute(_toolCallId, params) {
+          const { limit = 10, sessionKey } = params as { limit?: number; sessionKey?: string };
+
+          try {
+            let eps = await client.episodes(limit);
+
+            if (sessionKey) {
+              eps = eps.filter((ep: any) => {
+                try {
+                  const prov = JSON.parse(ep.source_description ?? "");
+                  return prov.session_key === sessionKey;
+                } catch {
+                  return ep.source_description?.includes(`session=${sessionKey}`) ||
+                    ep.name?.includes(sessionKey);
+                }
+              });
+            }
+
+            if (eps.length === 0) {
+              return {
+                content: [{ type: "text", text: "No episodes found." }],
+                details: { count: 0 },
+              };
+            }
+
+            const lines = eps.map((ep: any, i: number) => {
+              let desc = "";
+              try {
+                const prov = JSON.parse(ep.source_description ?? "");
+                const parts: string[] = [];
+                if (prov.event) parts.push(`event=${prov.event}`);
+                if (prov.session_key) parts.push(`session=${prov.session_key}`);
+                if (prov.file) parts.push(`file=${prov.file}`);
+                desc = parts.join(" ");
+              } catch {
+                desc = ep.source_description ?? "";
+              }
+              const age = ep.created_at ? formatTimeAgo(ep.created_at) : "";
+              const content = ep.content ? ep.content.slice(0, 100) : "";
+              return `${i + 1}. **${ep.name ?? ep.uuid}** ${desc} (${age})${content ? `\n   ${content}` : ""}`;
+            });
+
+            return {
+              content: [{ type: "text", text: `${eps.length} episode(s):\n\n${lines.join("\n")}` }],
+              details: { count: eps.length },
+            };
+          } catch (err) {
+            return {
+              content: [{ type: "text", text: `Graphiti episodes failed: ${err instanceof Error ? err.message : String(err)}` }],
+            };
+          }
+        },
+      },
+      { name: "graphiti_episodes" },
+    );
+
     // ========================================================================
     // ContextEngine registration (OpenClaw v2026.3.7+)
     // ========================================================================

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -29,7 +29,7 @@
       },
       "recallMaxFacts": {
         "type": "number",
-        "default": 1,
+        "default": 10,
         "description": "Max facts to inject on auto-recall"
       },
       "minPromptLength": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@robertogongora/graphiti",
-  "version": "0.6.2",
+  "version": "0.7.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@robertogongora/graphiti",
-      "version": "0.6.2",
+      "version": "0.7.0-beta.1",
       "license": "MIT",
       "dependencies": {
         "@sinclair/typebox": "^0.34.48"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robertogongora/graphiti",
-  "version": "0.7.0",
+  "version": "0.7.0-beta.1",
   "description": "Graphiti temporal knowledge graph plugin for OpenClaw",
   "type": "module",
   "main": "index.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robertogongora/graphiti",
-  "version": "0.6.2",
+  "version": "0.7.0",
   "description": "Graphiti temporal knowledge graph plugin for OpenClaw",
   "type": "module",
   "main": "index.ts",

--- a/shared.ts
+++ b/shared.ts
@@ -61,6 +61,40 @@ export function buildProvenance(
 }
 
 /**
+ * Strip plugin-injected metadata and noise from text before graph ingestion.
+ * Prevents feedback loops where recalled context is re-ingested as new knowledge.
+ */
+export function sanitizeForCapture(text: string): string {
+  let t = text;
+
+  // Strip <graphiti-context>...</graphiti-context> blocks (multiline)
+  t = t.replace(/<graphiti-context>[\s\S]*?<\/graphiti-context>/g, "");
+
+  // Strip <relevant-memories>...</relevant-memories> blocks (multiline)
+  t = t.replace(/<relevant-memories>[\s\S]*?<\/relevant-memories>/g, "");
+
+  // Strip conversation metadata JSON blocks: ```json\n{"schema":"openclaw.inbound_meta...}```
+  t = t.replace(/```json\s*\n\s*\{["\s]*schema["\s]*:\s*"openclaw\.inbound_meta[\s\S]*?```/g, "");
+
+  // Strip sender metadata JSON blocks: ```json\n{"label":...,"id":...,"sender":...}```
+  t = t.replace(/```json\s*\n\s*\{["\s]*label[\s\S]*?sender[\s\S]*?```/g, "");
+
+  // Strip [Subagent Context] prefixed lines
+  t = t.replace(/^\[Subagent Context\].*$/gm, "");
+
+  // Strip leading timestamps like [Mon 2026-03-15 14:00 UTC]
+  t = t.replace(/^\[(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun)\s+\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}\s+\w+\][ \t]*/gm, "");
+
+  // Strip null bytes
+  t = t.replace(/\u0000/g, "");
+
+  // Collapse multiple blank lines to max 2
+  t = t.replace(/\n{3,}/g, "\n\n");
+
+  return t.trim();
+}
+
+/**
  * Extract text content from a message's content field.
  * Handles both string content and content-block-array format.
  * Returns null if no usable text found or text is below minLength.

--- a/shared.ts
+++ b/shared.ts
@@ -76,14 +76,14 @@ export function sanitizeForCapture(text: string): string {
   // Strip conversation metadata JSON blocks: ```json\n{"schema":"openclaw.inbound_meta...}```
   t = t.replace(/```json\s*\n\s*\{["\s]*schema["\s]*:\s*"openclaw\.inbound_meta[\s\S]*?```/g, "");
 
-  // Strip sender metadata JSON blocks: ```json\n{"label":...,"id":...,"sender":...}```
-  t = t.replace(/```json\s*\n\s*\{["\s]*label[\s\S]*?sender[\s\S]*?```/g, "");
+  // Strip sender metadata JSON blocks containing both "label" and "sender" keys (order-independent)
+  t = t.replace(/```json\s*\n\s*\{(?=[\s\S]*?"label")(?=[\s\S]*?"sender")[\s\S]*?```/g, "");
 
   // Strip [Subagent Context] prefixed lines
   t = t.replace(/^\[Subagent Context\].*$/gm, "");
 
   // Strip leading timestamps like [Mon 2026-03-15 14:00 UTC]
-  t = t.replace(/^\[(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun)\s+\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}\s+\w+\][ \t]*/gm, "");
+  t = t.replace(/^\[(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun)\s+\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}\s+[A-Za-z]{2,5}\][ \t]*/gm, "");
 
   // Strip null bytes
   t = t.replace(/\u0000/g, "");

--- a/test/cli-search.test.ts
+++ b/test/cli-search.test.ts
@@ -69,6 +69,7 @@ describe("CLI search command", () => {
 
     expect(logs.some((l) => l.includes("WORKS_AT"))).toBe(true);
     expect(logs.some((l) => l.includes("Alice works at Acme Corp"))).toBe(true);
+    expect(logs.some((l) => l.includes("2024-01-15"))).toBe(true);
   });
 
   test("no results prints message", async () => {

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -194,4 +194,20 @@ describe("GraphitiClient", () => {
     await clientWithKey().search("test");
     expect(lastHeaders["/search"]?.["authorization"]).toBeUndefined();
   });
+
+  // -- multi-group search --
+
+  test("search() sends custom group_ids when provided", async () => {
+    await client().search("test", 5, ["group-a", "group-b"]);
+    expect(lastRequest["/search"]).toEqual({
+      query: "test",
+      group_ids: ["group-a", "group-b"],
+      max_facts: 5,
+    });
+  });
+
+  test("search() falls back to default groupId when groupIds omitted", async () => {
+    await client().search("test", 5);
+    expect((lastRequest["/search"] as any).group_ids).toEqual(["test-group"]);
+  });
 });

--- a/test/context-engine.test.ts
+++ b/test/context-engine.test.ts
@@ -620,6 +620,49 @@ describe("GraphitiContextEngine", () => {
 
       expect(lastRequest["/messages"]).toBeUndefined();
     });
+
+    test("sanitizes summary content before ingestion", async () => {
+      const engine = createEngine();
+      const summaryWithNoise = [
+        "<graphiti-context>Recalled facts that should be stripped</graphiti-context>",
+        "[Mon 2026-03-15 14:00 UTC] Timestamped line that should be stripped",
+        "[Subagent Context] This metadata line should be stripped",
+        "The actual subagent finding about architecture and design patterns",
+      ].join("\n");
+
+      await engine.onSubagentEnded({
+        childSessionKey: "child-sanitize",
+        reason: "completed",
+        summary: summaryWithNoise,
+      });
+
+      const req = lastRequest["/messages"] as any;
+      expect(req).toBeDefined();
+      // Noise should be stripped
+      expect(req.messages[0].content).not.toContain("<graphiti-context>");
+      expect(req.messages[0].content).not.toContain("[Subagent Context]");
+      expect(req.messages[0].content).not.toContain("[Mon 2026-03-15");
+      // Actual content should survive
+      expect(req.messages[0].content).toContain("actual subagent finding");
+    });
+
+    test("sanitizes messages content before ingestion", async () => {
+      const engine = createEngine();
+      await engine.onSubagentEnded({
+        childSessionKey: "child-sanitize-msgs",
+        reason: "completed",
+        messages: [
+          { role: "user", content: "<graphiti-context>Old recalled facts</graphiti-context>\nInvestigate the performance issue in the API" },
+          { role: "assistant", content: "The bottleneck is in the database query layer due to missing indexes" },
+        ],
+      });
+
+      const req = lastRequest["/messages"] as any;
+      expect(req).toBeDefined();
+      expect(req.messages[0].content).not.toContain("<graphiti-context>");
+      expect(req.messages[0].content).toContain("performance issue");
+      expect(req.messages[0].content).toContain("bottleneck");
+    });
   });
 
   // ========================================================================

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -62,6 +62,8 @@ export type MockOverrides = {
   ingestBody?: Record<string, unknown>;
   searchStatus?: number;
   searchErrorBody?: string;
+  episodes?: any[];
+  episodesStatus?: number;
 };
 
 let server: http.Server;
@@ -173,8 +175,14 @@ export function startMockServer(): Promise<void> {
           group_id: url.pathname.split("/")[2],
           last_n: url.searchParams.get("last_n"),
         };
+        const epStatus = mockOverrides.episodesStatus ?? 200;
+        if (epStatus !== 200) {
+          res.writeHead(epStatus);
+          res.end(JSON.stringify({ detail: "episodes error" }));
+          return;
+        }
         res.writeHead(200, { "Content-Type": "application/json" });
-        res.end(JSON.stringify(SAMPLE_EPISODES));
+        res.end(JSON.stringify(mockOverrides.episodes ?? SAMPLE_EPISODES));
         return;
       }
 

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -178,6 +178,24 @@ export function startMockServer(): Promise<void> {
         return;
       }
 
+      // DELETE /entity-edge/:uuid
+      if (req.method === "DELETE" && url.pathname.startsWith("/entity-edge/")) {
+        const uuid = url.pathname.split("/")[2];
+        lastRequest["/entity-edge"] = { uuid };
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ status: "ok" }));
+        return;
+      }
+
+      // DELETE /episode/:uuid
+      if (req.method === "DELETE" && url.pathname.startsWith("/episode/")) {
+        const uuid = url.pathname.split("/")[2];
+        lastRequest["/episode"] = { uuid };
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ status: "ok" }));
+        return;
+      }
+
       res.writeHead(404);
       res.end(JSON.stringify({ detail: "Not Found" }));
     });

--- a/test/hooks.test.ts
+++ b/test/hooks.test.ts
@@ -260,6 +260,46 @@ describe("hooks", () => {
       expect(req.messages[0].content).toContain("event-driven");
     });
 
+    test("sanitizes captured content (strips graphiti-context blocks)", async () => {
+      const { default: plugin } = await import("../index.js");
+      const { api, hooks } = createMockApi();
+      plugin.register(api as any);
+
+      const handler = hooks["before_compaction"][0];
+      await handler({
+        messages: [
+          {
+            role: "user",
+            content: "What is the architecture of our system?",
+          },
+          {
+            role: "assistant",
+            content:
+              "<graphiti-context>\nRecalled facts\n</graphiti-context>\nThe system uses microservices.",
+          },
+          {
+            role: "user",
+            content: "Tell me more about the graph database.",
+          },
+          {
+            role: "assistant",
+            content:
+              "Neo4j stores entities and relationships as a knowledge graph.",
+          },
+        ],
+        messageCount: 4,
+      }, createMockHookCtx());
+
+      const req = lastRequest["/messages"] as any;
+      expect(req).toBeDefined();
+      // graphiti-context block should be stripped by sanitizeForCapture
+      expect(req.messages[0].content).not.toContain("<graphiti-context>");
+      expect(req.messages[0].content).not.toContain("Recalled facts");
+      // Actual content should remain
+      expect(req.messages[0].content).toContain("microservices");
+      expect(req.messages[0].content).toContain("Neo4j");
+    });
+
     test("sessionKey from event propagates into provenance", async () => {
       const { default: plugin } = await import("../index.js");
       const { api, hooks } = createMockApi();
@@ -461,6 +501,43 @@ describe("hooks", () => {
       expect(prov.agent).toBe("test-agent");
       expect(prov.channel).toBe("test-channel");
       expect(req.messages[0].name).toContain("session-reset-test-session-key-");
+    });
+
+    test("sanitizes captured content in reset hook", async () => {
+      const { default: plugin } = await import("../index.js");
+      const { api, hooks } = createMockApi();
+      plugin.register(api as any);
+
+      const handler = hooks["before_reset"][0];
+      await handler({
+        messages: [
+          {
+            role: "user",
+            content: "Let me tell you about our deployment setup.",
+          },
+          {
+            role: "assistant",
+            content:
+              "<graphiti-context>\nOld recalled data\n</graphiti-context>\nWe use Kubernetes.",
+          },
+          {
+            role: "user",
+            content: "How does the rollback work?",
+          },
+          {
+            role: "assistant",
+            content:
+              "ArgoCD supports automatic rollback on health check failure.",
+          },
+        ],
+      }, createMockHookCtx());
+
+      const req = lastRequest["/messages"] as any;
+      expect(req).toBeDefined();
+      expect(req.messages[0].content).not.toContain("<graphiti-context>");
+      expect(req.messages[0].content).not.toContain("Old recalled data");
+      expect(req.messages[0].content).toContain("Kubernetes");
+      expect(req.messages[0].content).toContain("ArgoCD");
     });
 
     test("skips when fewer than 4 messages", async () => {

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -44,10 +44,10 @@ describe("registration", () => {
 
     plugin.register(api as any);
 
-    // 2 tools: graphiti_search, graphiti_ingest
-    expect(tools).toHaveLength(2);
+    // 3 tools: graphiti_search, graphiti_ingest, graphiti_forget
+    expect(tools).toHaveLength(3);
     expect(tools.map((t) => t.opts.name)).toEqual(
-      expect.arrayContaining(["graphiti_search", "graphiti_ingest"]),
+      expect.arrayContaining(["graphiti_search", "graphiti_ingest", "graphiti_forget"]),
     );
 
     // 4 hooks by default (autoRecall=false, autoCapture=true, autoIndex=true):

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -44,10 +44,10 @@ describe("registration", () => {
 
     plugin.register(api as any);
 
-    // 3 tools: graphiti_search, graphiti_ingest, graphiti_forget
-    expect(tools).toHaveLength(3);
+    // 4 tools: graphiti_search, graphiti_ingest, graphiti_forget, graphiti_episodes
+    expect(tools).toHaveLength(4);
     expect(tools.map((t) => t.opts.name)).toEqual(
-      expect.arrayContaining(["graphiti_search", "graphiti_ingest", "graphiti_forget"]),
+      expect.arrayContaining(["graphiti_search", "graphiti_ingest", "graphiti_forget", "graphiti_episodes"]),
     );
 
     // 4 hooks by default (autoRecall=false, autoCapture=true, autoIndex=true):

--- a/test/sanitize.test.ts
+++ b/test/sanitize.test.ts
@@ -31,6 +31,11 @@ describe("sanitizeForCapture", () => {
     expect(sanitizeForCapture(input)).toBe("before\n\nafter");
   });
 
+  test("strips sender metadata JSON blocks with reversed key order", () => {
+    const input = 'before\n```json\n{"sender":"alice","id":"u1","label":"User"}\n```\nafter';
+    expect(sanitizeForCapture(input)).toBe("before\n\nafter");
+  });
+
   test("strips [Subagent Context] prefixed lines", () => {
     const input = "line1\n[Subagent Context] some context here\nline2";
     expect(sanitizeForCapture(input)).toBe("line1\n\nline2");
@@ -44,6 +49,17 @@ describe("sanitizeForCapture", () => {
   test("strips timestamps on multiple lines", () => {
     const input = "[Tue 2026-03-15 09:30 PST] First\n[Wed 2026-03-16 10:00 EST] Second";
     expect(sanitizeForCapture(input)).toBe("First\nSecond");
+  });
+
+  test("does not strip timestamps with overly long timezone strings", () => {
+    const input = "[Mon 2026-03-15 14:00 TOOLONG] Hello there";
+    // "TOOLONG" is 7 chars — exceeds the [A-Za-z]{2,5} limit, should NOT match
+    expect(sanitizeForCapture(input)).toBe(input);
+  });
+
+  test("strips timestamps with short timezone abbreviations (2-5 chars)", () => {
+    const input = "[Mon 2026-03-15 14:00 CET] Hello\n[Tue 2026-03-16 09:00 CEST] World";
+    expect(sanitizeForCapture(input)).toBe("Hello\nWorld");
   });
 
   test("strips null bytes", () => {

--- a/test/sanitize.test.ts
+++ b/test/sanitize.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Unit tests for sanitizeForCapture().
+ */
+
+import { describe, test, expect } from "vitest";
+import { sanitizeForCapture } from "../shared.js";
+
+describe("sanitizeForCapture", () => {
+  test("strips <graphiti-context> blocks", () => {
+    const input = "before\n<graphiti-context>\nsome recalled facts\n</graphiti-context>\nafter";
+    expect(sanitizeForCapture(input)).toBe("before\n\nafter");
+  });
+
+  test("strips multiline <graphiti-context> blocks", () => {
+    const input = "<graphiti-context>\nRelevant knowledge graph facts (auto-recalled):\n- **WORKS_AT**: Alice works at Acme\n</graphiti-context>";
+    expect(sanitizeForCapture(input)).toBe("");
+  });
+
+  test("strips <relevant-memories> blocks", () => {
+    const input = "hello\n<relevant-memories>\nmemory data\n</relevant-memories>\nworld";
+    expect(sanitizeForCapture(input)).toBe("hello\n\nworld");
+  });
+
+  test("strips conversation metadata JSON blocks", () => {
+    const input = 'before\n```json\n{"schema":"openclaw.inbound_meta","version":1}\n```\nafter';
+    expect(sanitizeForCapture(input)).toBe("before\n\nafter");
+  });
+
+  test("strips sender metadata JSON blocks", () => {
+    const input = 'before\n```json\n{"label":"User","id":"u1","sender":"alice"}\n```\nafter';
+    expect(sanitizeForCapture(input)).toBe("before\n\nafter");
+  });
+
+  test("strips [Subagent Context] prefixed lines", () => {
+    const input = "line1\n[Subagent Context] some context here\nline2";
+    expect(sanitizeForCapture(input)).toBe("line1\n\nline2");
+  });
+
+  test("strips leading timestamps", () => {
+    const input = "[Mon 2026-03-15 14:00 UTC] Hello there";
+    expect(sanitizeForCapture(input)).toBe("Hello there");
+  });
+
+  test("strips timestamps on multiple lines", () => {
+    const input = "[Tue 2026-03-15 09:30 PST] First\n[Wed 2026-03-16 10:00 EST] Second";
+    expect(sanitizeForCapture(input)).toBe("First\nSecond");
+  });
+
+  test("strips null bytes", () => {
+    const input = "hello\u0000world\u0000test";
+    expect(sanitizeForCapture(input)).toBe("helloworldtest");
+  });
+
+  test("collapses multiple blank lines to max 2", () => {
+    const input = "a\n\n\n\n\nb";
+    expect(sanitizeForCapture(input)).toBe("a\n\nb");
+  });
+
+  test("passes through clean text unchanged", () => {
+    const input = "Alice works at Acme Corp and prefers dark mode.";
+    expect(sanitizeForCapture(input)).toBe(input);
+  });
+
+  test("returns empty string for empty input", () => {
+    expect(sanitizeForCapture("")).toBe("");
+  });
+
+  test("returns empty string for text that is entirely metadata", () => {
+    const input = "<graphiti-context>\nfacts\n</graphiti-context>";
+    expect(sanitizeForCapture(input)).toBe("");
+  });
+
+  test("handles combined patterns", () => {
+    const input = [
+      "[Mon 2026-03-15 14:00 UTC] User said something",
+      "<graphiti-context>\nold facts\n</graphiti-context>",
+      "[Subagent Context] task result",
+      '```json\n{"schema":"openclaw.inbound_meta","v":1}\n```',
+      "The actual content we want to keep.",
+    ].join("\n");
+    const result = sanitizeForCapture(input);
+    expect(result).toContain("User said something");
+    expect(result).toContain("The actual content we want to keep.");
+    expect(result).not.toContain("graphiti-context");
+    expect(result).not.toContain("Subagent Context");
+    expect(result).not.toContain("openclaw.inbound_meta");
+  });
+
+  test("trims leading and trailing whitespace", () => {
+    const input = "  \n\nhello\n\n  ";
+    expect(sanitizeForCapture(input)).toBe("hello");
+  });
+});

--- a/test/tools.test.ts
+++ b/test/tools.test.ts
@@ -181,6 +181,38 @@ describe("tool execution", () => {
     expect(result.content[0].text).toContain("specify a UUID");
   });
 
+  test("graphiti_forget rejects query mode with type=episode", async () => {
+    const { default: plugin } = await import("../index.js");
+    const { api, tools } = createMockApi();
+    plugin.register(api as any);
+
+    const tool = tools.find((t) => t.opts.name === "graphiti_forget")!.tool;
+    const result = await tool.execute("call-f-ep-query", { query: "some episode", type: "episode" });
+
+    expect(result.details.deleted).toBe(false);
+    expect(result.details.reason).toBe("episode_query_not_supported");
+    expect(result.content[0].text).toContain("not supported");
+    expect(result.content[0].text).toContain("UUID");
+    // Should NOT have attempted a search
+    expect(lastRequest["/search"]).toBeUndefined();
+  });
+
+  test("graphiti_forget error response includes details object", async () => {
+    mockOverrides.searchStatus = 500;
+    const { default: plugin } = await import("../index.js");
+    const { api, tools } = createMockApi();
+    plugin.register(api as any);
+
+    const tool = tools.find((t) => t.opts.name === "graphiti_forget")!.tool;
+    const result = await tool.execute("call-f-err", { query: "test" });
+
+    expect(result.content[0].text).toContain("Graphiti forget failed");
+    expect(result.details).toBeDefined();
+    expect(result.details.deleted).toBe(false);
+    expect(result.details.reason).toBe("error");
+    expect(result.details.error).toBeDefined();
+  });
+
   test("graphiti_forget returns error when neither query nor uuid provided", async () => {
     const { default: plugin } = await import("../index.js");
     const { api, tools } = createMockApi();

--- a/test/tools.test.ts
+++ b/test/tools.test.ts
@@ -133,12 +133,13 @@ describe("tool execution", () => {
     const { api, tools } = createMockApi();
     plugin.register(api as any);
 
+    const validUuid = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
     const tool = tools.find((t) => t.opts.name === "graphiti_forget")!.tool;
-    const result = await tool.execute("call-f1", { uuid: "fact-001", type: "fact" });
+    const result = await tool.execute("call-f1", { uuid: validUuid, type: "fact" });
 
-    expect(result.content[0].text).toContain("Deleted fact fact-001");
+    expect(result.content[0].text).toContain(`Deleted fact ${validUuid}`);
     expect(result.details.deleted).toBe(true);
-    expect(lastRequest["/entity-edge"]).toEqual({ uuid: "fact-001" });
+    expect(lastRequest["/entity-edge"]).toEqual({ uuid: validUuid });
   });
 
   test("graphiti_forget deletes episode by UUID", async () => {
@@ -146,12 +147,13 @@ describe("tool execution", () => {
     const { api, tools } = createMockApi();
     plugin.register(api as any);
 
+    const validUuid = "b2c3d4e5-f6a7-8901-bcde-f12345678901";
     const tool = tools.find((t) => t.opts.name === "graphiti_forget")!.tool;
-    const result = await tool.execute("call-f2", { uuid: "ep-001", type: "episode" });
+    const result = await tool.execute("call-f2", { uuid: validUuid, type: "episode" });
 
-    expect(result.content[0].text).toContain("Deleted episode ep-001");
+    expect(result.content[0].text).toContain(`Deleted episode ${validUuid}`);
     expect(result.details.deleted).toBe(true);
-    expect(lastRequest["/episode"]).toEqual({ uuid: "ep-001" });
+    expect(lastRequest["/episode"]).toEqual({ uuid: validUuid });
   });
 
   test("graphiti_forget auto-deletes single search match", async () => {
@@ -222,6 +224,36 @@ describe("tool execution", () => {
     const result = await tool.execute("call-f5", {});
 
     expect(result.content[0].text).toContain("provide either");
+    expect(result.details).toBeDefined();
+    expect(result.details.deleted).toBe(false);
+    expect(result.details.reason).toBe("missing_params");
+  });
+
+  test("graphiti_forget rejects invalid UUID format", async () => {
+    const { default: plugin } = await import("../index.js");
+    const { api, tools } = createMockApi();
+    plugin.register(api as any);
+
+    const tool = tools.find((t) => t.opts.name === "graphiti_forget")!.tool;
+    const result = await tool.execute("call-f-bad-uuid", { uuid: "../admin", type: "fact" });
+
+    expect(result.content[0].text).toContain("Invalid UUID format");
+    expect(result.details.deleted).toBe(false);
+    expect(result.details.reason).toBe("invalid_uuid");
+    // Should NOT have sent a DELETE request
+    expect(lastRequest["/entity-edge"]).toBeUndefined();
+  });
+
+  test("graphiti_forget accepts valid UUID format", async () => {
+    const { default: plugin } = await import("../index.js");
+    const { api, tools } = createMockApi();
+    plugin.register(api as any);
+
+    const tool = tools.find((t) => t.opts.name === "graphiti_forget")!.tool;
+    const result = await tool.execute("call-f-good-uuid", { uuid: "a1b2c3d4-e5f6-7890-abcd-ef1234567890", type: "fact" });
+
+    expect(result.details.deleted).toBe(true);
+    expect(lastRequest["/entity-edge"]).toEqual({ uuid: "a1b2c3d4-e5f6-7890-abcd-ef1234567890" });
   });
 
   // -- graphiti_episodes --
@@ -238,6 +270,30 @@ describe("tool execution", () => {
     expect(result.details.count).toBe(1);
   });
 
+  test("graphiti_episodes error response includes details object", async () => {
+    // Force the episodes endpoint to return 500 — the client returns []
+    // for HTTP errors, so the tool returns "No episodes found" (the empty path).
+    // This verifies the error path IS reachable by using a non-iterable value.
+    // Set episodes to an object (not array) — client passes it through, then
+    // eps.filter() throws because a plain object has no .filter method.
+    mockOverrides.episodes = { broken: true } as any;
+
+    const { default: plugin } = await import("../index.js");
+    const { api, tools } = createMockApi();
+    plugin.register(api as any);
+
+    const tool = tools.find((t) => t.opts.name === "graphiti_episodes")!.tool;
+    // Use sessionKey to trigger the filter path which calls .filter() on the object
+    const result = await tool.execute("call-ep-err", { sessionKey: "trigger-error" });
+
+    // The error should be caught and return a details object
+    expect(result.content[0].text).toContain("Graphiti episodes failed");
+    expect(result.details).toBeDefined();
+    expect(result.details.count).toBe(0);
+    expect(result.details.reason).toBe("error");
+    expect(result.details.error).toBeDefined();
+  });
+
   test("graphiti_episodes filters by sessionKey", async () => {
     const { default: plugin } = await import("../index.js");
     const { api, tools } = createMockApi();
@@ -248,5 +304,54 @@ describe("tool execution", () => {
 
     expect(result.content[0].text).toContain("No episodes found");
     expect(result.details.count).toBe(0);
+  });
+
+  test("graphiti_episodes sessionKey compensation preserves matching episodes beyond initial limit", async () => {
+    // Simulate: limit=2, but the matching episode is at position 4 (beyond limit).
+    // The fetch-more heuristic (limit * 5 = 10) should fetch enough to find it.
+    const targetSessionKey = "target-session-abc";
+    mockOverrides.episodes = [
+      {
+        uuid: "ep-unrelated-1", name: "unrelated-1", created_at: "2024-01-15T10:30:00+00:00",
+        source_description: JSON.stringify({ event: "after_turn", session_key: "other-session-1" }),
+        content: "Unrelated episode 1",
+      },
+      {
+        uuid: "ep-unrelated-2", name: "unrelated-2", created_at: "2024-01-15T10:31:00+00:00",
+        source_description: JSON.stringify({ event: "after_turn", session_key: "other-session-2" }),
+        content: "Unrelated episode 2",
+      },
+      {
+        uuid: "ep-unrelated-3", name: "unrelated-3", created_at: "2024-01-15T10:32:00+00:00",
+        source_description: JSON.stringify({ event: "after_turn", session_key: "other-session-3" }),
+        content: "Unrelated episode 3",
+      },
+      {
+        uuid: "ep-target-1", name: "target-episode", created_at: "2024-01-15T10:33:00+00:00",
+        source_description: JSON.stringify({ event: "after_turn", session_key: targetSessionKey }),
+        content: "This is the matching episode beyond initial limit",
+      },
+      {
+        uuid: "ep-target-2", name: "target-episode-2", created_at: "2024-01-15T10:34:00+00:00",
+        source_description: JSON.stringify({ event: "compact", session_key: targetSessionKey }),
+        content: "Second matching episode",
+      },
+    ];
+
+    const { default: plugin } = await import("../index.js");
+    const { api, tools } = createMockApi();
+    plugin.register(api as any);
+
+    const tool = tools.find((t) => t.opts.name === "graphiti_episodes")!.tool;
+    const result = await tool.execute("call-ep-compensation", { limit: 2, sessionKey: targetSessionKey });
+
+    // Both matching episodes should be found (compensation fetched more than limit)
+    expect(result.details.count).toBe(2);
+    expect(result.content[0].text).toContain("2 episode(s)");
+    expect(result.content[0].text).toContain("target-episode");
+
+    // Verify the server was asked for more than limit (limit * 5 = 10)
+    const episodesReq = lastRequest["/episodes"] as any;
+    expect(Number(episodesReq.last_n)).toBe(10); // limit * 5
   });
 });

--- a/test/tools.test.ts
+++ b/test/tools.test.ts
@@ -191,4 +191,30 @@ describe("tool execution", () => {
 
     expect(result.content[0].text).toContain("provide either");
   });
+
+  // -- graphiti_episodes --
+
+  test("graphiti_episodes returns formatted list", async () => {
+    const { default: plugin } = await import("../index.js");
+    const { api, tools } = createMockApi();
+    plugin.register(api as any);
+
+    const tool = tools.find((t) => t.opts.name === "graphiti_episodes")!.tool;
+    const result = await tool.execute("call-ep1", {});
+
+    expect(result.content[0].text).toContain("1 episode(s)");
+    expect(result.details.count).toBe(1);
+  });
+
+  test("graphiti_episodes filters by sessionKey", async () => {
+    const { default: plugin } = await import("../index.js");
+    const { api, tools } = createMockApi();
+    plugin.register(api as any);
+
+    const tool = tools.find((t) => t.opts.name === "graphiti_episodes")!.tool;
+    const result = await tool.execute("call-ep2", { sessionKey: "nonexistent" });
+
+    expect(result.content[0].text).toContain("No episodes found");
+    expect(result.details.count).toBe(0);
+  });
 });

--- a/test/tools.test.ts
+++ b/test/tools.test.ts
@@ -13,6 +13,7 @@ import {
   createMockApi,
   mockOverrides,
   lastRequest,
+  SAMPLE_FACTS,
 } from "./helpers.js";
 
 describe("tool execution", () => {
@@ -123,5 +124,71 @@ describe("tool execution", () => {
     const result = await tool.execute("call-5", { content: "test" });
 
     expect(result.content[0].text).toContain("Graphiti ingest failed");
+  });
+
+  // -- graphiti_forget --
+
+  test("graphiti_forget deletes fact by UUID", async () => {
+    const { default: plugin } = await import("../index.js");
+    const { api, tools } = createMockApi();
+    plugin.register(api as any);
+
+    const tool = tools.find((t) => t.opts.name === "graphiti_forget")!.tool;
+    const result = await tool.execute("call-f1", { uuid: "fact-001", type: "fact" });
+
+    expect(result.content[0].text).toContain("Deleted fact fact-001");
+    expect(result.details.deleted).toBe(true);
+    expect(lastRequest["/entity-edge"]).toEqual({ uuid: "fact-001" });
+  });
+
+  test("graphiti_forget deletes episode by UUID", async () => {
+    const { default: plugin } = await import("../index.js");
+    const { api, tools } = createMockApi();
+    plugin.register(api as any);
+
+    const tool = tools.find((t) => t.opts.name === "graphiti_forget")!.tool;
+    const result = await tool.execute("call-f2", { uuid: "ep-001", type: "episode" });
+
+    expect(result.content[0].text).toContain("Deleted episode ep-001");
+    expect(result.details.deleted).toBe(true);
+    expect(lastRequest["/episode"]).toEqual({ uuid: "ep-001" });
+  });
+
+  test("graphiti_forget auto-deletes single search match", async () => {
+    mockOverrides.searchFacts = [SAMPLE_FACTS[0]];
+    const { default: plugin } = await import("../index.js");
+    const { api, tools } = createMockApi();
+    plugin.register(api as any);
+
+    const tool = tools.find((t) => t.opts.name === "graphiti_forget")!.tool;
+    const result = await tool.execute("call-f3", { query: "Alice" });
+
+    expect(result.details.deleted).toBe(true);
+    expect(result.details.uuid).toBe("fact-001");
+    expect(lastRequest["/entity-edge"]).toEqual({ uuid: "fact-001" });
+  });
+
+  test("graphiti_forget lists multiple matches without deleting", async () => {
+    const { default: plugin } = await import("../index.js");
+    const { api, tools } = createMockApi();
+    plugin.register(api as any);
+
+    const tool = tools.find((t) => t.opts.name === "graphiti_forget")!.tool;
+    const result = await tool.execute("call-f4", { query: "test" });
+
+    expect(result.details.deleted).toBe(false);
+    expect(result.details.reason).toBe("multiple_matches");
+    expect(result.content[0].text).toContain("specify a UUID");
+  });
+
+  test("graphiti_forget returns error when neither query nor uuid provided", async () => {
+    const { default: plugin } = await import("../index.js");
+    const { api, tools } = createMockApi();
+    plugin.register(api as any);
+
+    const tool = tools.find((t) => t.opts.name === "graphiti_forget")!.tool;
+    const result = await tool.execute("call-f5", {});
+
+    expect(result.content[0].text).toContain("provide either");
   });
 });


### PR DESCRIPTION
## Summary
Phase 1 quick wins batch: 6 feature changes + docs/version bump.

- **Input sanitization** — `sanitizeForCapture()` strips `<graphiti-context>`, `<relevant-memories>`, metadata JSON blocks, `[Subagent Context]` lines, timestamps, and null bytes before graph ingestion. Applied at all 4 ContextEngine ingestion points.
- **`graphiti_forget` tool** — Delete facts/episodes by UUID or search-then-delete by query. New `deleteEdge()` and `deleteEpisode()` client methods.
- **`graphiti_episodes` tool** — List recent ingestion records with optional session key filtering.
- **Multi-group search** — `graphiti_search` and `client.search()` accept optional `groupIds` to search across multiple graph groups.
- **CLI temporal info** — `openclaw graphiti search` now shows `valid_at`/`invalid_at` per fact.
- **`recallMaxFacts` default 1 → 10** — Aligns with ContextEngine default.

## Test plan
- [x] All 210 tests pass (`npx vitest run`)
- [x] New `test/sanitize.test.ts` (15 tests) covers all strip patterns
- [x] New tool tests for `graphiti_forget` (5 tests) and `graphiti_episodes` (2 tests)
- [x] New client tests for multi-group `search()` (2 tests)
- [x] All endpoints validated against Graphiti server source (`/server/graph_service/routers/`)

Closes #24, Closes #27, Closes #17, Closes #21, Closes #46, Closes #107, Closes #59, Closes #96