### PR TITLE
fix: expose episode UUID in graphiti_episodes output (#162)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- **`graphiti_episodes` UUID display**: Episode output now includes `**uuid: ...**`
+  prefix for each episode, making it easier to use with `graphiti_forget`. Unnamed
+  episodes show `(unnamed)` instead of duplicating the UUID.
+
 ## [0.7.0-beta.1] — 2026-03-22
 
 > Beta release for P1 quick wins.

--- a/index.ts
+++ b/index.ts
@@ -385,7 +385,7 @@ const graphitiPlugin = {
               }
               const age = ep.created_at ? formatTimeAgo(ep.created_at) : "";
               const content = ep.content ? ep.content.slice(0, 100) : "";
-              return `${i + 1}. **${ep.name ?? ep.uuid}** ${desc} (${age})${content ? `\n   ${content}` : ""}`;
+              return `${i + 1}. **uuid: ${ep.uuid}** ${ep.name ?? ep.uuid} ${desc} (${age})${content ? `\n   ${content}` : ""}`;
             });
 
             return {

--- a/index.ts
+++ b/index.ts
@@ -385,7 +385,7 @@ const graphitiPlugin = {
               }
               const age = ep.created_at ? formatTimeAgo(ep.created_at) : "";
               const content = ep.content ? ep.content.slice(0, 100) : "";
-              return `${i + 1}. **uuid: ${ep.uuid}** ${ep.name ?? ep.uuid} ${desc} (${age})${content ? `\n   ${content}` : ""}`;
+              return `${i + 1}. **uuid: ${ep.uuid}** ${ep.name ? `**${ep.name}**` : "(unnamed)"} ${desc} (${age})${content ? `\n   ${content}` : ""}`;
             });
 
             return {

--- a/test/tools.test.ts
+++ b/test/tools.test.ts
@@ -268,6 +268,33 @@ describe("tool execution", () => {
 
     expect(result.content[0].text).toContain("1 episode(s)");
     expect(result.content[0].text).toContain("**uuid: ep-001**");
+    expect(result.content[0].text).toContain("**session-reset-1700000000000**");
+    expect(result.details.count).toBe(1);
+  });
+
+  test("graphiti_episodes unnamed episode does not duplicate UUID", async () => {
+    mockOverrides.episodes = [
+      {
+        uuid: "ep-unnamed-1",
+        created_at: "2024-01-15T10:30:00+00:00",
+        source_description: JSON.stringify({ event: "after_turn", session_key: "sess-1" }),
+        content: "Some content",
+      },
+    ];
+
+    const { default: plugin } = await import("../index.js");
+    const { api, tools } = createMockApi();
+    plugin.register(api as any);
+
+    const tool = tools.find((t) => t.opts.name === "graphiti_episodes")!.tool;
+    const result = await tool.execute("call-ep-unnamed", {});
+
+    expect(result.content[0].text).toContain("**uuid: ep-unnamed-1**");
+    expect(result.content[0].text).toContain("(unnamed)");
+    // UUID should NOT appear twice (once in prefix, once as name fallback)
+    const text = result.content[0].text;
+    const uuidOccurrences = text.split("ep-unnamed-1").length - 1;
+    expect(uuidOccurrences).toBe(1);
     expect(result.details.count).toBe(1);
   });
 

--- a/test/tools.test.ts
+++ b/test/tools.test.ts
@@ -267,6 +267,7 @@ describe("tool execution", () => {
     const result = await tool.execute("call-ep1", {});
 
     expect(result.content[0].text).toContain("1 episode(s)");
+    expect(result.content[0].text).toContain("**uuid: ep-001**");
     expect(result.details.count).toBe(1);
   });
 
@@ -348,6 +349,8 @@ describe("tool execution", () => {
     // Both matching episodes should be found (compensation fetched more than limit)
     expect(result.details.count).toBe(2);
     expect(result.content[0].text).toContain("2 episode(s)");
+    expect(result.content[0].text).toContain("**uuid: ep-target-1**");
+    expect(result.content[0].text).toContain("**uuid: ep-target-2**");
     expect(result.content[0].text).toContain("target-episode");
 
     // Verify the server was asked for more than limit (limit * 5 = 10)


### PR DESCRIPTION
## Summary
- prepend episode UUID in `graphiti_episodes` formatted output as `**uuid: ...**`
- keep existing name/provenance/age/content formatting intact
- update tool tests to assert UUID is included in output

## Testing
- npm test

Closes #162