### PR TITLE
feat: Smart autoRecall — session-aware continuity after reset/timeout/compaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,12 +16,16 @@
     Normal turns with sufficient message history get zero auto-injection.
   - **Output**: separate `<graphiti-continuity>` and `<graphiti-context>` blocks
     for clear debugging and feedback-loop prevention via `sanitizeForCapture()`.
-  - **Limitation**: after `/new` or session reset, the new session file is empty
-    so Stage A cannot recover prior context. Cross-session episode recovery
-    requires session lineage metadata tracked in #155.
+  - **Episode-based fallback** (Stage A.5): when the session file is empty or
+    missing (after `/new`, timeout, or resume), `assemble()` now queries recent
+    episodes from the knowledge graph and filters by `session_key` provenance to
+    recover what was discussed in the same session. This closes the reset/timeout
+    gap where Stage A had nothing to recover.
 
-- **Provenance scaffolding**: `thread_id` field added to `SessionMeta` and
-  `buildProvenance()` for future saga/thread support (#155).
+- **`thread_id` wired end-to-end**: `thread_id` is now populated from runtime
+  context (`HookContext.threadId`), stored in episode provenance across all
+  capture paths (ingest, afterTurn, compact, ingestBatch, onSubagentEnded), and
+  used by episode-based continuity recovery to prefer same-thread episodes.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,15 @@
   capture paths (ingest, afterTurn, compact, ingestBatch, onSubagentEnded), and
   used by episode-based continuity recovery to prefer same-thread episodes.
 
+### Fixed
+
+- **`autoRecall: false` now honored in ContextEngine mode**: `assemble()` returns
+  a pass-through when `autoRecall` is not explicitly `true`, matching the
+  documented opt-in default. Capture and compaction still work regardless.
+- **Session-scoped `thread_id` scoring**: `extractEpisodeContinuity()` now
+  requires a `session_key` match before considering `thread_id` as a tiebreaker,
+  preventing cross-session content leakage via reused thread IDs.
+
 ### Changed
 
 - Legacy hooks `before_agent_start` now uses shared `formatFactsAsContext()`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- **Smart autoRecall** (#164): `assemble()` is now a two-stage continuity-aware
+  pipeline that only fires when context loss is detected — not every turn.
+  - **Stage A** reads the tail of the JSONL session transcript (bounded 128KB chunk)
+    to recover what was actually discussed.
+  - **Stage B** uses the recovered continuity text as the `/search` query for
+    targeted semantic fact retrieval. Falls back to `/get-memory` with the current
+    message window when no session file is available.
+  - **Trigger conditions**: continuity gaps (bootstrap, compaction, ≤3 messages)
+    and deictic references ("continue", "as I mentioned", "where we left off").
+    Normal turns with sufficient message history get zero auto-injection.
+  - **Output**: separate `<graphiti-continuity>` and `<graphiti-context>` blocks
+    for clear debugging and feedback-loop prevention via `sanitizeForCapture()`.
+  - **Limitation**: after `/new` or session reset, the new session file is empty
+    so Stage A cannot recover prior context. Cross-session episode recovery
+    requires session lineage metadata tracked in #155.
+
+- **Provenance scaffolding**: `thread_id` field added to `SessionMeta` and
+  `buildProvenance()` for future saga/thread support (#155).
+
+### Changed
+
+- Legacy hooks `before_agent_start` now uses shared `formatFactsAsContext()`
+  instead of inline fact formatting.
+
 ## [0.7.0-beta.2] — 2026-03-22
 
 > Beta release with fix for episode UUID display.

--- a/README.md
+++ b/README.md
@@ -106,10 +106,14 @@ By default, `autoRecall` is **off**. The agent can search the knowledge graph at
 time using the `graphiti_search` tool — this is the recommended approach. The agent
 decides when graph context is relevant rather than injecting facts on every turn.
 
-When `autoRecall: true`, the plugin fires `before_agent_start`, searches Graphiti with
-the incoming prompt, and injects matching facts as a `<graphiti-context>` block. This
-adds latency and token cost to every message. Useful when you want persistent background
-context without explicitly calling `graphiti_search`.
+When `autoRecall: true`, the plugin injects relevant knowledge graph facts before
+turns that need them. In **ContextEngine mode** (v0.7.0+), this uses Smart autoRecall —
+a two-stage pipeline that only fires on continuity gaps (bootstrap, compaction, reset,
+few messages) or when the user references prior context. Stage A recovers continuity
+from the session transcript or recent episodes; Stage B runs a targeted semantic recall
+(`/search` against recovered continuity, or `/get-memory` on the current window as
+fallback). In **hooks mode**, it fires `before_agent_start` on every turn. Useful when
+you want persistent background context without explicitly calling `graphiti_search`.
 
 ```json
 {
@@ -157,7 +161,7 @@ methods that the runtime calls directly:
 
 | Lifecycle method | Replaces hook | Purpose |
 |------------------|---------------|---------|
-| `assemble()` | `before_agent_start` | Recall relevant facts into the system prompt |
+| `assemble()` | `before_agent_start` | Smart autoRecall — conditionally inject continuity and facts |
 | `ingest()` | _(new)_ | Ingest a single message into the graph |
 | `ingestBatch()` | _(new)_ | Batch-ingest multiple messages |
 | `afterTurn()` | _(new)_ | Ingest new messages after each turn (replaces batch fallback) |
@@ -188,6 +192,7 @@ Every ingested episode carries a JSON-encoded provenance object in `source_descr
   "ts": "2026-03-05T10:30:00.000Z",
   "group_id": "core",
   "session_key": "sess-abc-123",
+  "thread_id": "thread-xyz",
   "agent": "main",
   "channel": "slack",
   "session_start": "2026-03-06T10:00:00.000Z"
@@ -207,8 +212,8 @@ Every ingested episode carries a JSON-encoded provenance object in `source_descr
 | `compact` | ContextEngine graph-aware compaction |
 | `subagent_ended` | ContextEngine subagent result ingestion |
 
-Session fields (`session_key`, `agent`, `channel`, `session_start`) are included
-when available and omitted otherwise. The `openclaw graphiti episodes` command
+Session fields (`session_key`, `thread_id`, `agent`, `channel`, `session_start`) are
+included when available and omitted otherwise. The `openclaw graphiti episodes` command
 parses this automatically and shows a human-readable summary. Legacy episodes
 with plain-text `source_description` still display gracefully.
 

--- a/context-engine.ts
+++ b/context-engine.ts
@@ -192,6 +192,13 @@ export class GraphitiContextEngine {
         return passThrough;
       }
 
+      // Respect opt-in config — engine still registers for capture/compaction
+      // but recall injection requires explicit autoRecall: true
+      if (!this.cfg.autoRecall) {
+        this.debugLog.log("ce-assemble", { skipped: true, reason: "autoRecall_disabled" });
+        return passThrough;
+      }
+
       if (params.threadId) this._threadId = params.threadId;
 
       const lastUserText = this.extractLastUserText(params.messages);

--- a/context-engine.ts
+++ b/context-engine.ts
@@ -9,7 +9,7 @@
 import { createRequire } from "node:module";
 import type { GraphitiClient, GraphitiMessage } from "./client.js";
 import type { DebugLog } from "./debug-log.js";
-import { buildEpisodeName, buildProvenance, extractTextContent, extractTextsFromMessages, formatContinuityBlock, formatFactsAsContext, hasDeicticReferences, isContinuityGap, readSessionFileTail, sanitizeForCapture } from "./shared.js";
+import { buildEpisodeName, buildProvenance, extractEpisodeContinuity, extractTextContent, extractTextsFromMessages, formatContinuityBlock, formatFactsAsContext, hasDeicticReferences, isContinuityGap, readSessionFileTail, sanitizeForCapture } from "./shared.js";
 
 const _require = createRequire(import.meta.url);
 const PLUGIN_VERSION: string = (_require("./package.json") as any).version;
@@ -88,6 +88,8 @@ export class GraphitiContextEngine {
   /** Smart autoRecall state — tracks lifecycle events for continuity gap detection. */
   private _lastEvent: string | null = null;
   private _sessionFile: string | null = null;
+  private _sessionId: string | null = null;
+  private _threadId: string | null = null;
 
   constructor(
     private client: GraphitiClient,
@@ -151,7 +153,7 @@ export class GraphitiContextEngine {
         role,
         name: `ingest-${params.sessionId}-${Date.now()}`,
         timestamp: new Date().toISOString(),
-        source_description: buildProvenance(this.groupId, { event: "ingest" }),
+        source_description: buildProvenance(this.groupId, { event: "ingest", session_key: params.sessionId, thread_id: this._threadId ?? undefined }),
       }]);
 
       this.debugLog.log("ce-ingest", { ingested: true, role, ms: Date.now() - start });
@@ -178,6 +180,7 @@ export class GraphitiContextEngine {
     sessionId: string;
     messages: unknown[];
     tokenBudget?: number;
+    threadId?: string;
   }): Promise<AssembleResult> {
     const passThrough: AssembleResult = { messages: params.messages };
     const start = Date.now();
@@ -188,6 +191,8 @@ export class GraphitiContextEngine {
         this.debugLog.log("ce-assemble", { skipped: true, reason: "unhealthy" });
         return passThrough;
       }
+
+      if (params.threadId) this._threadId = params.threadId;
 
       const lastUserText = this.extractLastUserText(params.messages);
       const gapDetected = isContinuityGap(params.messages.length, { recentEvent: this._lastEvent });
@@ -210,6 +215,18 @@ export class GraphitiContextEngine {
         continuityTail = await readSessionFileTail(this._sessionFile);
         if (continuityTail) {
           continuityBlock = formatContinuityBlock(continuityTail);
+        }
+      }
+
+      // Stage A fallback: episode-based recovery when session file is empty/missing
+      if (!continuityTail && this._sessionId) {
+        const episodes = await this.client.episodes(20);
+        const episodeText = extractEpisodeContinuity(episodes, this._sessionId, {
+          threadId: this._threadId ?? undefined,
+        });
+        if (episodeText) {
+          continuityTail = episodeText;
+          continuityBlock = formatContinuityBlock(episodeText);
         }
       }
 
@@ -340,7 +357,7 @@ export class GraphitiContextEngine {
           role: "conversation",
           name: buildEpisodeName("compact", { sessionKey: params.sessionId }),
           timestamp: new Date().toISOString(),
-          source_description: buildProvenance(this.groupId, { event: "compact", session_key: params.sessionId }),
+          source_description: buildProvenance(this.groupId, { event: "compact", session_key: params.sessionId, thread_id: this._threadId ?? undefined }),
         }]);
 
         this._lastEvent = "compact";
@@ -406,6 +423,7 @@ export class GraphitiContextEngine {
         source_description: buildProvenance(this.groupId, {
           event: "ingest_batch",
           session_key: params.sessionId,
+          thread_id: this._threadId ?? undefined,
         }),
       }]);
 
@@ -430,8 +448,9 @@ export class GraphitiContextEngine {
     isHeartbeat?: boolean;
     tokenBudget?: number;
   }): Promise<void> {
-    // Keep session file reference fresh for Smart autoRecall
+    // Keep session state fresh for Smart autoRecall
     if (params.sessionFile) this._sessionFile = params.sessionFile;
+    if (params.sessionId) this._sessionId = params.sessionId;
 
     if (this.cfg.autoCapture === false) {
       this.debugLog.log("ce-afterTurn", { skipped: true, reason: "autoCapture_disabled" });
@@ -492,6 +511,7 @@ export class GraphitiContextEngine {
         source_description: buildProvenance(this.groupId, {
           event,
           session_key: params.sessionId,
+          thread_id: this._threadId ?? undefined,
         }),
       }]);
 
@@ -510,9 +530,12 @@ export class GraphitiContextEngine {
   async bootstrap(params: {
     sessionId: string;
     sessionFile?: string;
+    threadId?: string;
   }): Promise<BootstrapResult> {
     try {
       this._sessionFile = params.sessionFile ?? null;
+      this._sessionId = params.sessionId;
+      this._threadId = params.threadId ?? this._threadId;
 
       const healthy = await this.cachedHealthy();
       if (!healthy) {
@@ -582,6 +605,7 @@ export class GraphitiContextEngine {
         source_description: buildProvenance(this.groupId, {
           event: "subagent_ended",
           session_key: params.childSessionKey,
+          thread_id: this._threadId ?? undefined,
         }),
       }]);
 

--- a/context-engine.ts
+++ b/context-engine.ts
@@ -9,7 +9,7 @@
 import { createRequire } from "node:module";
 import type { GraphitiClient, GraphitiMessage } from "./client.js";
 import type { DebugLog } from "./debug-log.js";
-import { buildEpisodeName, buildProvenance, extractTextContent, extractTextsFromMessages, formatFactsAsContext, sanitizeForCapture } from "./shared.js";
+import { buildEpisodeName, buildProvenance, extractTextContent, extractTextsFromMessages, formatContinuityBlock, formatFactsAsContext, hasDeicticReferences, isContinuityGap, readSessionFileTail, sanitizeForCapture } from "./shared.js";
 
 const _require = createRequire(import.meta.url);
 const PLUGIN_VERSION: string = (_require("./package.json") as any).version;
@@ -84,6 +84,10 @@ export class GraphitiContextEngine {
   /** Cached healthy() result with TTL to avoid redundant HTTP round-trips. */
   private _healthCache: { result: boolean; ts: number } | null = null;
   private static readonly HEALTH_CACHE_TTL_MS = 15_000;
+
+  /** Smart autoRecall state — tracks lifecycle events for continuity gap detection. */
+  private _lastEvent: string | null = null;
+  private _sessionFile: string | null = null;
 
   constructor(
     private client: GraphitiClient,
@@ -160,8 +164,15 @@ export class GraphitiContextEngine {
   }
 
   /**
-   * Assemble context for the agent by recalling relevant facts.
-   * Uses the richer /get-memory endpoint with the full message array.
+   * Assemble context for the agent via Smart autoRecall.
+   *
+   * Only fires when a continuity gap is detected (bootstrap, compaction,
+   * few messages) or the user prompt contains deictic references to prior
+   * context. Normal turns with sufficient history get no injection.
+   *
+   * Two-stage pipeline:
+   *   A. Continuity recovery from session transcript (JSONL file tail)
+   *   B. Targeted semantic recall via /get-memory
    */
   async assemble(params: {
     sessionId: string;
@@ -178,57 +189,113 @@ export class GraphitiContextEngine {
         return passThrough;
       }
 
-      // Convert the last N messages to GraphitiMessage format for /get-memory
-      const recentMessages = params.messages.slice(-10);
-      const graphitiMessages: GraphitiMessage[] = [];
+      const lastUserText = this.extractLastUserText(params.messages);
+      const gapDetected = isContinuityGap(params.messages.length, { recentEvent: this._lastEvent });
+      const deicticDetected = !!lastUserText && hasDeicticReferences(lastUserText);
 
-      for (const msg of recentMessages) {
-        if (!msg || typeof msg !== "object") continue;
-        const m = msg as Record<string, unknown>;
-        const role = m.role as string;
-        if (role !== "user" && role !== "assistant") continue;
-
-        const text = extractTextContent(m.content, 1);
-        if (!text) continue;
-
-        graphitiMessages.push({
-          content: text.slice(0, 2000),
-          role_type: role as "user" | "assistant",
-          role,
-        });
-      }
-
-      if (graphitiMessages.length === 0) {
-        this.debugLog.log("ce-assemble", { skipped: true, reason: "no_messages" });
+      if (!gapDetected && !deicticDetected) {
+        this.debugLog.log("ce-assemble", { skipped: true, reason: "no_recovery_needed" });
         return passThrough;
       }
 
-      // TODO: /get-memory only accepts single group_id — multi-group recall needs server changes
+      // Consume the one-shot event flag
+      const triggerEvent = this._lastEvent;
+      this._lastEvent = null;
       const maxFacts = this.cfg.recallMaxFacts ?? 10;
-      const facts = await this.client.getMemory(graphitiMessages, maxFacts);
 
-      if (facts.length === 0) {
-        this.debugLog.log("ce-assemble", { count: 0, ms: Date.now() - start });
+      // Stage A: recover continuity from session transcript
+      let continuityBlock: string | null = null;
+      let continuityTail: string | null = null;
+      if (this._sessionFile) {
+        continuityTail = await readSessionFileTail(this._sessionFile);
+        if (continuityTail) {
+          continuityBlock = formatContinuityBlock(continuityTail);
+        }
+      }
+
+      // Stage B: semantic recall — use recovered continuity as the query
+      // so facts are relevant to what was actually discussed, not to the
+      // possibly-empty current message window
+      let semanticBlock: string | null = null;
+      if (continuityTail) {
+        const query = continuityTail.slice(-2000);
+        const facts = await this.client.search(query, maxFacts);
+        if (facts.length > 0) {
+          semanticBlock = formatFactsAsContext(facts);
+        }
+      } else {
+        const graphitiMessages = this.buildGraphitiMessages(params.messages);
+        if (graphitiMessages.length > 0) {
+          const facts = await this.client.getMemory(graphitiMessages, maxFacts);
+          if (facts.length > 0) {
+            semanticBlock = formatFactsAsContext(facts);
+          }
+        }
+      }
+
+      // --- Combine ---
+      const parts = [continuityBlock, semanticBlock].filter(Boolean) as string[];
+      if (parts.length === 0) {
+        this.debugLog.log("ce-assemble", { recovery: true, trigger: triggerEvent ?? "deictic", empty: true, ms: Date.now() - start });
         return passThrough;
       }
 
-      const systemPromptAddition = formatFactsAsContext(facts);
-
+      const systemPromptAddition = parts.join("\n\n");
       const estimatedTokens = Math.ceil(systemPromptAddition.length / 4);
+      const trigger = triggerEvent ?? (deicticDetected ? "deictic" : "gap");
 
-      this.logger?.info?.(`graphiti: assembled ${facts.length} facts for context`);
-      this.debugLog.log("ce-assemble", { count: facts.length, tokens: estimatedTokens, ms: Date.now() - start });
+      this.logger?.info?.(`graphiti: smart autoRecall fired (trigger=${trigger}, continuity=${!!continuityBlock}, facts=${semanticBlock ? "yes" : "none"})`);
+      this.debugLog.log("ce-assemble", {
+        recovery: true,
+        trigger,
+        hasContinuity: !!continuityBlock,
+        factCount: semanticBlock ? (semanticBlock.match(/^- \*\*/gm)?.length ?? 0) : 0,
+        tokens: estimatedTokens,
+        ms: Date.now() - start,
+      });
 
-      return {
-        messages: params.messages,
-        systemPromptAddition,
-        estimatedTokens,
-      };
+      return { messages: params.messages, systemPromptAddition, estimatedTokens };
     } catch (err) {
       this.logger?.warn(`graphiti: assemble failed: ${String(err)}`);
       this.debugLog.log("ce-assemble", { error: String(err), ms: Date.now() - start });
       return passThrough;
     }
+  }
+
+  /** Convert raw messages to GraphitiMessage format for /get-memory. */
+  private buildGraphitiMessages(messages: unknown[]): GraphitiMessage[] {
+    const recentMessages = messages.slice(-10);
+    const graphitiMessages: GraphitiMessage[] = [];
+
+    for (const msg of recentMessages) {
+      if (!msg || typeof msg !== "object") continue;
+      const m = msg as Record<string, unknown>;
+      const role = m.role as string;
+      if (role !== "user" && role !== "assistant") continue;
+
+      const text = extractTextContent(m.content, 1);
+      if (!text) continue;
+
+      graphitiMessages.push({
+        content: text.slice(0, 2000),
+        role_type: role as "user" | "assistant",
+        role,
+      });
+    }
+
+    return graphitiMessages;
+  }
+
+  /** Extract the text of the last user message for deictic reference detection. */
+  private extractLastUserText(messages: unknown[]): string | null {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const msg = messages[i];
+      if (!msg || typeof msg !== "object") continue;
+      const m = msg as Record<string, unknown>;
+      if (m.role !== "user") continue;
+      return extractTextContent(m.content, 1);
+    }
+    return null;
   }
 
   /**
@@ -276,11 +343,13 @@ export class GraphitiContextEngine {
           source_description: buildProvenance(this.groupId, { event: "compact", session_key: params.sessionId }),
         }]);
 
+        this._lastEvent = "compact";
         this.debugLog.log("ce-compact", { action: "ingested", texts: texts.length, compacted: true });
         return { ok: true, compacted: true };
       }
 
       if (params.legacyParams?.bridge) {
+        this._lastEvent = "compact";
         this.debugLog.log("ce-compact", { action: "legacy_bridge" });
         await params.legacyParams.bridge.compact();
         return { ok: true, compacted: true };
@@ -361,6 +430,9 @@ export class GraphitiContextEngine {
     isHeartbeat?: boolean;
     tokenBudget?: number;
   }): Promise<void> {
+    // Keep session file reference fresh for Smart autoRecall
+    if (params.sessionFile) this._sessionFile = params.sessionFile;
+
     if (this.cfg.autoCapture === false) {
       this.debugLog.log("ce-afterTurn", { skipped: true, reason: "autoCapture_disabled" });
       return;
@@ -432,18 +504,23 @@ export class GraphitiContextEngine {
   }
 
   /**
-   * Bootstrap: health-check the server and report graph population.
+   * Bootstrap: health-check the server, report graph population,
+   * and prime Smart autoRecall state for continuity recovery.
    */
-  async bootstrap(_params: {
+  async bootstrap(params: {
     sessionId: string;
     sessionFile?: string;
   }): Promise<BootstrapResult> {
     try {
+      this._sessionFile = params.sessionFile ?? null;
+
       const healthy = await this.cachedHealthy();
       if (!healthy) {
         this.debugLog.log("ce-bootstrap", { healthy: false });
         return { bootstrapped: false, reason: "server-unhealthy" };
       }
+
+      this._lastEvent = "bootstrap";
 
       const stats = await this.client.episodeCount();
       this.debugLog.log("ce-bootstrap", { healthy: true, episodes: stats.count });

--- a/context-engine.ts
+++ b/context-engine.ts
@@ -173,8 +173,10 @@ export class GraphitiContextEngine {
    * context. Normal turns with sufficient history get no injection.
    *
    * Two-stage pipeline:
-   *   A. Continuity recovery from session transcript (JSONL file tail)
-   *   B. Targeted semantic recall via /get-memory
+   *   A. Continuity recovery — session transcript tail, then episode-based
+   *      fallback (filtered by session_key/thread_id provenance)
+   *   B. Targeted semantic recall — /search against recovered continuity,
+   *      or /get-memory on the current window when no continuity is available
    */
   async assemble(params: {
     sessionId: string;

--- a/index.ts
+++ b/index.ts
@@ -22,7 +22,7 @@ import os from "node:os";
 import { GraphitiClient, type GraphitiEpisode } from "./client.js";
 import { DebugLog, NOOP_LOG } from "./debug-log.js";
 import { extractMemoryPath, upsertIndexEpisode, scanMemoryFiles, readIndexState, writeIndexState, readMemoryFileMeta, buildIndexContent, indexEpisodeName, isIndexableFile, DEFAULT_INDEX_EXTENSIONS } from "./memory-index.js";
-import { buildProvenance, extractTextsFromMessages, buildEpisodeName, sanitizeForCapture, type SessionMeta } from "./shared.js";
+import { buildProvenance, extractTextsFromMessages, buildEpisodeName, formatFactsAsContext, sanitizeForCapture, type SessionMeta } from "./shared.js";
 import { GraphitiContextEngine } from "./context-engine.js";
 
 // Re-export public types from shared.ts for backwards compatibility
@@ -444,14 +444,10 @@ const graphitiPlugin = {
           const facts = await client.search(event.prompt, recallMaxFacts);
           if (facts.length === 0) return;
 
-          const context = facts.map((f) => `- **${f.name}**: ${f.fact}`).join("\n");
           api.logger.info?.(`graphiti: recalled ${facts.length} facts for context injection`);
           debugLog.log("recall", { group: groupId, count: facts.length, ms: Date.now() - start });
 
-          return {
-            prependContext:
-              `<graphiti-context>\nRelevant knowledge graph facts (auto-recalled):\n${context}\n</graphiti-context>`,
-          };
+          return { prependContext: formatFactsAsContext(facts) };
         } catch (err) {
           api.logger.warn(`graphiti: recall failed: ${String(err)}`);
         }

--- a/index.ts
+++ b/index.ts
@@ -49,6 +49,7 @@ interface HookContext {
   agentId?: string;
   messageProvider?: string;
   messageChannel?: string;
+  threadId?: string;
   [key: string]: unknown; // allow extension without breaking
 }
 
@@ -108,6 +109,7 @@ const graphitiPlugin = {
       if (ctx.agentId) meta.agent = ctx.agentId;
       if (ctx.messageProvider) meta.channel = ctx.messageProvider;
       else if (ctx.messageChannel) meta.channel = ctx.messageChannel;
+      if (ctx.threadId) meta.threadId = ctx.threadId;
       if (ctx.sessionId && sessionStarts.has(ctx.sessionId)) {
         meta.sessionStart = sessionStarts.get(ctx.sessionId);
       }
@@ -490,6 +492,7 @@ const graphitiPlugin = {
             source_description: buildProvenance(groupId, {
               event: "before_compaction",
               session_key: meta.sessionKey,
+              thread_id: meta.threadId,
               agent: meta.agent,
               channel: meta.channel,
               session_start: meta.sessionStart,
@@ -533,6 +536,7 @@ const graphitiPlugin = {
             source_description: buildProvenance(groupId, {
               event: "before_reset",
               session_key: meta.sessionKey,
+              thread_id: meta.threadId,
               agent: meta.agent,
               channel: meta.channel,
               session_start: meta.sessionStart,

--- a/shared.ts
+++ b/shared.ts
@@ -327,8 +327,10 @@ export function extractEpisodeContinuity(
 
     let score = 0;
     if (prov) {
-      if (prov.session_key === sessionKey) score = 1;
-      if (threadId && prov.thread_id === threadId) score = 2;
+      if (prov.session_key === sessionKey) {
+        score = 1;
+        if (threadId && prov.thread_id === threadId) score = 2;
+      }
     }
     if (score >= 1) {
       scored.push({ content: ep.content, score, created_at: ep.created_at ?? "" });

--- a/shared.ts
+++ b/shared.ts
@@ -4,6 +4,8 @@
  * Extracted to avoid circular dependencies and reduce duplication.
  */
 
+import fs from "node:fs/promises";
+
 /**
  * Session context embedded in episode provenance for traceability.
  * @exported - public API of this plugin
@@ -13,6 +15,7 @@ export interface SessionMeta {
   sessionStart?: string;
   agent?: string;
   channel?: string;
+  threadId?: string;
 }
 
 /**
@@ -36,6 +39,7 @@ export function buildProvenance(
   fields: {
     event: string;
     session_key?: string;
+    thread_id?: string;
     file?: string;
     file_type?: string;
     source?: string;
@@ -51,6 +55,7 @@ export function buildProvenance(
     group_id: groupId,
   };
   if (fields.session_key) prov.session_key = fields.session_key;
+  if (fields.thread_id) prov.thread_id = fields.thread_id;
   if (fields.file) prov.file = fields.file;
   if (fields.file_type) prov.file_type = fields.file_type;
   if (fields.source) prov.source = fields.source;
@@ -69,6 +74,9 @@ export function sanitizeForCapture(text: string): string {
 
   // Strip <graphiti-context>...</graphiti-context> blocks (multiline)
   t = t.replace(/<graphiti-context>[\s\S]*?<\/graphiti-context>/g, "");
+
+  // Strip <graphiti-continuity>...</graphiti-continuity> blocks (multiline)
+  t = t.replace(/<graphiti-continuity>[\s\S]*?<\/graphiti-continuity>/g, "");
 
   // Strip <relevant-memories>...</relevant-memories> blocks (multiline)
   t = t.replace(/<relevant-memories>[\s\S]*?<\/relevant-memories>/g, "");
@@ -173,4 +181,124 @@ export function extractTextsFromMessages(
 export function formatFactsAsContext(facts: { name: string; fact: string }[]): string {
   const context = facts.map((f) => `- **${f.name}**: ${f.fact}`).join("\n");
   return `<graphiti-context>\nRelevant knowledge graph facts (auto-recalled):\n${context}\n</graphiti-context>`;
+}
+
+// ---------------------------------------------------------------------------
+// Smart autoRecall helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Detect whether the current turn is likely a continuity gap —
+ * the runtime has lost recent conversational context.
+ */
+export function isContinuityGap(
+  messageCount: number,
+  opts?: { recentEvent?: string | null; threshold?: number },
+): boolean {
+  const threshold = opts?.threshold ?? 3;
+  const event = opts?.recentEvent;
+  if (event === "bootstrap" || event === "compact") return true;
+  return messageCount <= threshold;
+}
+
+/**
+ * Deictic patterns that signal the user expects continuity with prior context.
+ * Kept intentionally conservative to avoid false positives on normal prompts.
+ */
+const DEICTIC_PATTERNS = [
+  /\bas (?:I|we) (?:mentioned|said|discussed|talked about)\b/i,
+  /\bwhat we (?:just|were) (?:discussing|talking about)\b/i,
+  /\b(?:continue|go on|keep going|pick up where)\b/i,
+  /\bthat (?:thing|idea|approach|plan|issue|bug|feature|task)\b/i,
+  /\blike (?:I|we) said\b/i,
+  /\bremember when\b/i,
+  /\bback to (?:the|that|what)\b/i,
+  /\bwhere (?:we|I) left off\b/i,
+];
+
+/**
+ * Returns true if text contains references to prior conversational context
+ * that the model may not have in its current message window.
+ */
+export function hasDeicticReferences(text: string): boolean {
+  return DEICTIC_PATTERNS.some((p) => p.test(text));
+}
+
+/**
+ * Read the tail of a JSONL session file, returning the most recent
+ * user/assistant messages up to `maxChars` of formatted text.
+ *
+ * JSONL format (from OpenClaw):
+ *   { "type": "message", "message": { "role": "user"|"assistant", "content": ... } }
+ *
+ * Returns null if the file is missing, empty, or has no usable messages.
+ */
+export async function readSessionFileTail(
+  sessionFile: string,
+  maxChars = 8000,
+): Promise<string | null> {
+  // Read only a bounded tail chunk to avoid loading arbitrarily large session files.
+  // 128KB is generous headroom for the default 8000-char output budget.
+  const TAIL_BYTES = 128 * 1024;
+
+  let raw: string;
+  try {
+    const fh = await fs.open(sessionFile, "r");
+    try {
+      const stat = await fh.stat();
+      const readSize = Math.min(stat.size, TAIL_BYTES);
+      const buf = Buffer.alloc(readSize);
+      await fh.read(buf, 0, readSize, stat.size - readSize);
+      raw = buf.toString("utf-8");
+    } finally {
+      await fh.close();
+    }
+  } catch {
+    return null;
+  }
+
+  const lines = raw.split("\n");
+
+  const collected: string[] = [];
+  let totalChars = 0;
+
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const line = lines[i].trim();
+    if (!line) continue;
+
+    let record: any;
+    try {
+      record = JSON.parse(line);
+    } catch {
+      continue;
+    }
+
+    if (record?.type !== "message") continue;
+    const msg = record.message;
+    if (!msg || (msg.role !== "user" && msg.role !== "assistant")) continue;
+
+    const text = typeof msg.content === "string"
+      ? msg.content
+      : extractTextContent(msg.content, 1);
+    if (!text) continue;
+
+    const label = msg.role === "user" ? "User" : "Assistant";
+    const formatted = `${label}: ${text}`;
+
+    if (totalChars + formatted.length > maxChars && collected.length > 0) break;
+    collected.push(formatted);
+    totalChars += formatted.length;
+  }
+
+  if (collected.length === 0) return null;
+
+  collected.reverse();
+  return collected.join("\n");
+}
+
+/**
+ * Wrap recovered session transcript in a `<graphiti-continuity>` block.
+ */
+export function formatContinuityBlock(text: string): string {
+  return `<graphiti-continuity>\nRecent session context (recovered from transcript):\n${text}\n</graphiti-continuity>`;
 }

--- a/shared.ts
+++ b/shared.ts
@@ -302,3 +302,57 @@ export async function readSessionFileTail(
 export function formatContinuityBlock(text: string): string {
   return `<graphiti-continuity>\nRecent session context (recovered from transcript):\n${text}\n</graphiti-continuity>`;
 }
+
+/**
+ * Extract continuity text from recent episodes that share the same session/thread.
+ * Used as a fallback when the session JSONL file is empty or missing (e.g. after
+ * `/new` reset or timeout resume).
+ */
+export function extractEpisodeContinuity(
+  episodes: Array<{ source_description?: string; content?: string; created_at?: string }>,
+  sessionKey: string,
+  opts?: { threadId?: string; maxChars?: number },
+): string | null {
+  const maxChars = opts?.maxChars ?? 8000;
+  const threadId = opts?.threadId;
+
+  // Score and filter episodes by provenance match
+  const scored: Array<{ content: string; score: number; created_at: string }> = [];
+  for (const ep of episodes) {
+    if (!ep.content) continue;
+    let prov: Record<string, unknown> | null = null;
+    try {
+      if (ep.source_description) prov = JSON.parse(ep.source_description);
+    } catch { /* skip unparseable provenance */ }
+
+    let score = 0;
+    if (prov) {
+      if (prov.session_key === sessionKey) score = 1;
+      if (threadId && prov.thread_id === threadId) score = 2;
+    }
+    if (score >= 1) {
+      scored.push({ content: ep.content, score, created_at: ep.created_at ?? "" });
+    }
+  }
+
+  if (scored.length === 0) return null;
+
+  // Sort: highest score first, then newest first
+  scored.sort((a, b) => b.score - a.score || b.created_at.localeCompare(a.created_at));
+
+  // Collect content up to budget (account for \n\n joiner between parts)
+  const parts: string[] = [];
+  let chars = 0;
+  for (const ep of scored) {
+    const joinerCost = parts.length > 0 ? 2 : 0; // \n\n between parts
+    if (chars + joinerCost + ep.content.length > maxChars) {
+      const remaining = maxChars - chars - joinerCost;
+      if (remaining > 100) parts.push(ep.content.slice(0, remaining));
+      break;
+    }
+    parts.push(ep.content);
+    chars += joinerCost + ep.content.length;
+  }
+
+  return parts.length > 0 ? parts.join("\n\n") : null;
+}

--- a/test/context-engine.test.ts
+++ b/test/context-engine.test.ts
@@ -1209,6 +1209,31 @@ describe("GraphitiContextEngine", () => {
       expect(result.systemPromptAddition).not.toContain("<graphiti-continuity>");
       expect(result.systemPromptAddition).toContain("<graphiti-context>");
     });
+
+    test("reset with new/empty session file — no continuity, falls back to semantic only", async () => {
+      // Simulates /new or session reset: bootstrap receives a fresh empty transcript.
+      // Stage A has nothing to recover. Stage B falls back to getMemory on the
+      // current (shallow) message window. Cross-session episode recovery requires
+      // session lineage metadata (#155).
+      const emptySessionFile = path.join(tmpDir, "new-session.jsonl");
+      require("node:fs").writeFileSync(emptySessionFile, JSON.stringify({
+        type: "session", version: 2, id: "new-session", timestamp: new Date().toISOString(),
+      }));
+
+      const engine = createEngine();
+      await engine.bootstrap({ sessionId: "new-sess", sessionFile: emptySessionFile });
+
+      const result = await engine.assemble({
+        sessionId: "new-sess",
+        messages: [{ role: "user", content: "What were we just talking about?" }],
+      });
+
+      // No continuity block — empty session file has no messages
+      expect(result.systemPromptAddition).toBeDefined();
+      expect(result.systemPromptAddition).not.toContain("<graphiti-continuity>");
+      // Semantic recall still fires via getMemory fallback
+      expect(result.systemPromptAddition).toContain("<graphiti-context>");
+    });
   });
 
   // ========================================================================

--- a/test/context-engine.test.ts
+++ b/test/context-engine.test.ts
@@ -16,11 +16,12 @@ import {
   getMockPort,
   mockOverrides,
   lastRequest,
+  SAMPLE_EPISODES_WITH_SESSION,
 } from "./helpers.js";
 import { GraphitiClient } from "../client.js";
 import { NOOP_LOG } from "../debug-log.js";
 import { GraphitiContextEngine } from "../context-engine.js";
-import { formatFactsAsContext, isContinuityGap, hasDeicticReferences, readSessionFileTail, formatContinuityBlock } from "../shared.js";
+import { formatFactsAsContext, isContinuityGap, hasDeicticReferences, readSessionFileTail, formatContinuityBlock, extractEpisodeContinuity } from "../shared.js";
 import { createRequire } from "node:module";
 
 const _require = createRequire(import.meta.url);
@@ -1210,29 +1211,146 @@ describe("GraphitiContextEngine", () => {
       expect(result.systemPromptAddition).toContain("<graphiti-context>");
     });
 
-    test("reset with new/empty session file — no continuity, falls back to semantic only", async () => {
-      // Simulates /new or session reset: bootstrap receives a fresh empty transcript.
-      // Stage A has nothing to recover. Stage B falls back to getMemory on the
-      // current (shallow) message window. Cross-session episode recovery requires
-      // session lineage metadata (#155).
+    test("reset with empty session file — recovers continuity from same-session episodes", async () => {
+      mockOverrides.episodes = SAMPLE_EPISODES_WITH_SESSION;
       const emptySessionFile = path.join(tmpDir, "new-session.jsonl");
       require("node:fs").writeFileSync(emptySessionFile, JSON.stringify({
         type: "session", version: 2, id: "new-session", timestamp: new Date().toISOString(),
       }));
 
       const engine = createEngine();
-      await engine.bootstrap({ sessionId: "new-sess", sessionFile: emptySessionFile });
+      await engine.bootstrap({ sessionId: "sess-1", sessionFile: emptySessionFile });
 
       const result = await engine.assemble({
-        sessionId: "new-sess",
+        sessionId: "sess-1",
         messages: [{ role: "user", content: "What were we just talking about?" }],
       });
 
-      // No continuity block — empty session file has no messages
       expect(result.systemPromptAddition).toBeDefined();
-      expect(result.systemPromptAddition).not.toContain("<graphiti-continuity>");
-      // Semantic recall still fires via getMemory fallback
+      // Episode-based recovery should produce continuity block
+      expect(result.systemPromptAddition).toContain("<graphiti-continuity>");
+      expect(result.systemPromptAddition).toContain("microservices");
+      // Semantic block also present (search driven by episode content)
       expect(result.systemPromptAddition).toContain("<graphiti-context>");
+      // Should have used /search (not /get-memory) since continuity was recovered
+      expect(lastRequest["/search"]).toBeDefined();
+    });
+
+    test("episode recovery when no session file at all", async () => {
+      mockOverrides.episodes = SAMPLE_EPISODES_WITH_SESSION;
+
+      const engine = createEngine();
+      await engine.bootstrap({ sessionId: "sess-1" }); // no sessionFile
+
+      const result = await engine.assemble({
+        sessionId: "sess-1",
+        messages: [{ role: "user", content: "Continue where we left off" }],
+      });
+
+      expect(result.systemPromptAddition).toBeDefined();
+      expect(result.systemPromptAddition).toContain("<graphiti-continuity>");
+      expect(result.systemPromptAddition).toContain("microservices");
+    });
+
+    test("episode recovery filters by session_key — excludes other sessions", async () => {
+      mockOverrides.episodes = SAMPLE_EPISODES_WITH_SESSION;
+
+      const engine = createEngine();
+      await engine.bootstrap({ sessionId: "sess-1" });
+
+      const result = await engine.assemble({
+        sessionId: "sess-1",
+        messages: [{ role: "user", content: "What were we discussing?" }],
+      });
+
+      expect(result.systemPromptAddition).toContain("microservices");
+      expect(result.systemPromptAddition).not.toContain("Unrelated conversation from another session");
+    });
+
+    test("episode recovery returns null when no matching session — falls to getMemory", async () => {
+      mockOverrides.episodes = SAMPLE_EPISODES_WITH_SESSION;
+      // Use a different set of facts for /get-memory to prove it was called
+      mockOverrides.getMemoryFacts = [
+        { uuid: "f-gm-001", name: "FALLBACK", fact: "Fallback semantic fact from getMemory", valid_at: null, invalid_at: null, created_at: "2024-01-01T00:00:00Z", expired_at: null },
+      ];
+
+      const engine = createEngine();
+      await engine.bootstrap({ sessionId: "no-match-session" });
+
+      const result = await engine.assemble({
+        sessionId: "no-match-session",
+        messages: [{ role: "user", content: "Tell me something" }],
+      });
+
+      expect(result.systemPromptAddition).toBeDefined();
+      // No continuity block — no episodes match this session
+      expect(result.systemPromptAddition).not.toContain("<graphiti-continuity>");
+      // Falls to getMemory which returns the fallback facts
+      expect(result.systemPromptAddition).toContain("<graphiti-context>");
+      expect(result.systemPromptAddition).toContain("Fallback semantic fact from getMemory");
+    });
+
+    test("episode recovery prefers thread_id match over session_key-only", async () => {
+      mockOverrides.episodes = SAMPLE_EPISODES_WITH_SESSION;
+
+      const engine = createEngine();
+      await engine.bootstrap({ sessionId: "sess-1", threadId: "thread-a" });
+
+      const result = await engine.assemble({
+        sessionId: "sess-1",
+        messages: [{ role: "user", content: "Continue" }],
+      });
+
+      expect(result.systemPromptAddition).toContain("<graphiti-continuity>");
+      // thread-a episode ("deployment pipeline") should be prioritized
+      expect(result.systemPromptAddition).toContain("deployment pipeline");
+    });
+
+    test("skips episode fetch when session file has content", async () => {
+      mockOverrides.episodes = SAMPLE_EPISODES_WITH_SESSION;
+      const sessionFile = createSessionFile([
+        { role: "user", content: "This is the existing session file content about React hooks" },
+        { role: "assistant", content: "React hooks are used for state management and side effects." },
+      ]);
+
+      const engine = createEngine();
+      await engine.bootstrap({ sessionId: "sess-1", sessionFile });
+
+      const result = await engine.assemble({
+        sessionId: "sess-1",
+        messages: [{ role: "user", content: "Tell me more" }],
+      });
+
+      // Continuity from session file, not episodes
+      expect(result.systemPromptAddition).toContain("<graphiti-continuity>");
+      expect(result.systemPromptAddition).toContain("React hooks");
+      // Should use /search (driven by session file tail), not episode content
+      expect(lastRequest["/search"]).toBeDefined();
+      // Continuity should NOT contain episode content
+      expect(result.systemPromptAddition).not.toContain("microservices");
+    });
+
+    test("timeout/resume — recovers from episodes after bootstrap with no session file", async () => {
+      // Simulates a timeout-resume scenario: the runtime bootstraps a new session
+      // with no session file. Episodes from the prior session should be recovered.
+      mockOverrides.episodes = SAMPLE_EPISODES_WITH_SESSION;
+      mockOverrides.getMemoryFacts = [
+        { uuid: "f-unrelated", name: "UNRELATED", fact: "Completely unrelated fact", valid_at: null, invalid_at: null, created_at: "2024-01-01T00:00:00Z", expired_at: null },
+      ];
+
+      const engine = createEngine();
+      await engine.bootstrap({ sessionId: "sess-1" }); // no sessionFile — simulates resume
+
+      const result = await engine.assemble({
+        sessionId: "sess-1",
+        messages: [{ role: "user", content: "Where were we?" }],
+      });
+
+      // Should recover from episodes, NOT fall to getMemory
+      expect(result.systemPromptAddition).toContain("<graphiti-continuity>");
+      expect(result.systemPromptAddition).toContain("microservices");
+      // /search should be used (driven by episode content), not /get-memory
+      expect(lastRequest["/search"]).toBeDefined();
     });
   });
 
@@ -1407,6 +1525,106 @@ describe("GraphitiContextEngine", () => {
     test("wraps text in graphiti-continuity tags", () => {
       const result = formatContinuityBlock("User: Hello\nAssistant: Hi");
       expect(result).toBe("<graphiti-continuity>\nRecent session context (recovered from transcript):\nUser: Hello\nAssistant: Hi\n</graphiti-continuity>");
+    });
+  });
+
+  // ========================================================================
+  // extractEpisodeContinuity (unit tests)
+  // ========================================================================
+
+  describe("extractEpisodeContinuity", () => {
+    test("returns null when no episodes match session_key", () => {
+      const episodes = [
+        { source_description: JSON.stringify({ session_key: "other" }), content: "irrelevant" },
+      ];
+      expect(extractEpisodeContinuity(episodes, "my-session")).toBeNull();
+    });
+
+    test("returns content from matching session_key episodes", () => {
+      const episodes = [
+        { source_description: JSON.stringify({ session_key: "my-session" }), content: "user: Hello\nassistant: Hi", created_at: "2024-01-15T10:00:00Z" },
+        { source_description: JSON.stringify({ session_key: "other" }), content: "unrelated" },
+      ];
+      const result = extractEpisodeContinuity(episodes, "my-session");
+      expect(result).toBe("user: Hello\nassistant: Hi");
+    });
+
+    test("prefers thread_id match over session_key-only", () => {
+      const episodes = [
+        { source_description: JSON.stringify({ session_key: "s1" }), content: "session-only content", created_at: "2024-01-15T11:00:00Z" },
+        { source_description: JSON.stringify({ session_key: "s1", thread_id: "t1" }), content: "thread-matched content", created_at: "2024-01-15T10:00:00Z" },
+      ];
+      const result = extractEpisodeContinuity(episodes, "s1", { threadId: "t1" });
+      // thread-matched should come first despite being older
+      expect(result).toContain("thread-matched content");
+      expect(result!.indexOf("thread-matched")).toBeLessThan(result!.indexOf("session-only"));
+    });
+
+    test("respects maxChars budget", () => {
+      const episodes = [
+        { source_description: JSON.stringify({ session_key: "s1" }), content: "A".repeat(5000), created_at: "2024-01-15T11:00:00Z" },
+        { source_description: JSON.stringify({ session_key: "s1" }), content: "B".repeat(5000), created_at: "2024-01-15T10:00:00Z" },
+      ];
+      const result = extractEpisodeContinuity(episodes, "s1", { maxChars: 6000 });
+      expect(result).toBeDefined();
+      expect(result!.length).toBeLessThanOrEqual(6000);
+      // First episode fits; second is truncated
+      expect(result).toContain("A".repeat(5000));
+    });
+
+    test("returns null for episodes with no content", () => {
+      const episodes = [
+        { source_description: JSON.stringify({ session_key: "s1" }), content: "" },
+        { source_description: JSON.stringify({ session_key: "s1" }) },
+      ];
+      expect(extractEpisodeContinuity(episodes, "s1")).toBeNull();
+    });
+
+    test("handles unparseable source_description gracefully", () => {
+      const episodes = [
+        { source_description: "not-json", content: "some content" },
+        { source_description: JSON.stringify({ session_key: "s1" }), content: "valid content" },
+      ];
+      const result = extractEpisodeContinuity(episodes, "s1");
+      expect(result).toBe("valid content");
+    });
+  });
+
+  // ========================================================================
+  // thread_id provenance
+  // ========================================================================
+
+  describe("thread_id provenance", () => {
+    test("ingest includes thread_id in provenance when set via bootstrap", async () => {
+      const engine = createEngine();
+      await engine.bootstrap({ sessionId: "sess-1", threadId: "thread-abc" });
+      await engine.ingest({
+        sessionId: "sess-1",
+        message: { role: "user", content: "This is a test message for provenance checking" },
+      });
+
+      const req = lastRequest["/messages"] as any;
+      expect(req).toBeDefined();
+      const prov = JSON.parse(req.messages[0].source_description);
+      expect(prov.thread_id).toBe("thread-abc");
+      expect(prov.session_key).toBe("sess-1");
+    });
+
+    test("afterTurn includes thread_id in provenance", async () => {
+      const engine = createEngine();
+      await engine.bootstrap({ sessionId: "sess-1", threadId: "thread-xyz" });
+      await engine.afterTurn({
+        sessionId: "sess-1",
+        messages: [
+          { role: "user", content: "Hello there, how are you doing today?" },
+          { role: "assistant", content: "I am doing great, thank you for asking!" },
+        ],
+        prePromptMessageCount: 0,
+      });
+
+      const req = lastRequest["/messages"] as any;
+      const prov = JSON.parse(req.messages[0].source_description);
+      expect(prov.thread_id).toBe("thread-xyz");
     });
   });
 });

--- a/test/context-engine.test.ts
+++ b/test/context-engine.test.ts
@@ -5,7 +5,10 @@
  * and verifies each method against the mock HTTP server.
  */
 
-import { describe, test, expect, beforeAll, afterAll, beforeEach } from "vitest";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, test, expect, beforeAll, afterAll, beforeEach, afterEach } from "vitest";
 import {
   startMockServer,
   stopMockServer,
@@ -17,7 +20,7 @@ import {
 import { GraphitiClient } from "../client.js";
 import { NOOP_LOG } from "../debug-log.js";
 import { GraphitiContextEngine } from "../context-engine.js";
-import { formatFactsAsContext } from "../shared.js";
+import { formatFactsAsContext, isContinuityGap, hasDeicticReferences, readSessionFileTail, formatContinuityBlock } from "../shared.js";
 import { createRequire } from "node:module";
 
 const _require = createRequire(import.meta.url);
@@ -946,6 +949,439 @@ describe("GraphitiContextEngine", () => {
       expect(result).toContain("</graphiti-context>");
       expect(result).toContain("- **WORKS_AT**: Alice works at Acme Corp");
       expect(result).toContain("- **PREFERS**: User prefers dark mode");
+    });
+  });
+
+  // ========================================================================
+  // Smart autoRecall
+  // ========================================================================
+
+  describe("Smart autoRecall", () => {
+    let tmpDir: string;
+
+    beforeEach(async () => {
+      tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "graphiti-smart-recall-"));
+    });
+
+    afterEach(async () => {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    });
+
+    function createSessionFile(messages: Array<{ role: string; content: string }>): string {
+      const filePath = path.join(tmpDir, "session.jsonl");
+      const lines = [
+        JSON.stringify({ type: "session", version: 2, id: "test-session", timestamp: new Date().toISOString() }),
+        ...messages.map((m) => JSON.stringify({ type: "message", message: { role: m.role, content: m.content } })),
+      ];
+      // Write synchronously for simplicity in tests — file is small
+      require("node:fs").writeFileSync(filePath, lines.join("\n"));
+      return filePath;
+    }
+
+    test("fires after bootstrap with session file — produces both continuity and semantic blocks", async () => {
+      const sessionFile = createSessionFile([
+        { role: "user", content: "What is the architecture of the new feature?" },
+        { role: "assistant", content: "The feature uses a modular plugin architecture with event-driven communication." },
+        { role: "user", content: "How does the session file work?" },
+        { role: "assistant", content: "The session file is a JSONL format that records all conversation history." },
+      ]);
+
+      const engine = createEngine();
+      await engine.bootstrap({ sessionId: "sess-1", sessionFile });
+
+      const result = await engine.assemble({
+        sessionId: "sess-1",
+        messages: [{ role: "user", content: "Tell me about Alice" }],
+      });
+
+      expect(result.systemPromptAddition).toBeDefined();
+      expect(result.systemPromptAddition).toContain("<graphiti-continuity>");
+      expect(result.systemPromptAddition).toContain("</graphiti-continuity>");
+      expect(result.systemPromptAddition).toContain("architecture");
+      expect(result.systemPromptAddition).toContain("JSONL format");
+      // Semantic block should also be present
+      expect(result.systemPromptAddition).toContain("<graphiti-context>");
+      expect(result.systemPromptAddition).toContain("</graphiti-context>");
+    });
+
+    test("does not fire when many messages and no deictic refs", async () => {
+      const sessionFile = createSessionFile([
+        { role: "user", content: "Old conversation about something" },
+        { role: "assistant", content: "Old response about the topic" },
+      ]);
+
+      const engine = createEngine();
+      await engine.bootstrap({ sessionId: "sess-1", sessionFile });
+
+      // Clear the bootstrap event by consuming it
+      await engine.assemble({
+        sessionId: "sess-1",
+        messages: [{ role: "user", content: "First question after bootstrap" }],
+      });
+
+      // Now a normal turn with many messages — should NOT fire
+      const result = await engine.assemble({
+        sessionId: "sess-1",
+        messages: [
+          { role: "user", content: "First message in the conversation about testing" },
+          { role: "assistant", content: "Response about testing methodology and best practices" },
+          { role: "user", content: "Second question about the deployment pipeline" },
+          { role: "assistant", content: "Response about the CI/CD pipeline configuration" },
+          { role: "user", content: "What tools do we use for monitoring?" },
+        ],
+      });
+
+      expect(result.systemPromptAddition).toBeUndefined();
+    });
+
+    test("fires on deictic references even with sufficient messages", async () => {
+      const sessionFile = createSessionFile([
+        { role: "user", content: "We were discussing the migration strategy for the database" },
+        { role: "assistant", content: "The migration plan involves three phases with rollback support" },
+      ]);
+
+      const engine = createEngine();
+      await engine.bootstrap({ sessionId: "sess-1", sessionFile });
+
+      // Consume bootstrap event
+      await engine.assemble({
+        sessionId: "sess-1",
+        messages: [{ role: "user", content: "First question after bootstrap" }],
+      });
+
+      // Many messages but deictic reference — should fire
+      const result = await engine.assemble({
+        sessionId: "sess-1",
+        messages: [
+          { role: "user", content: "First message about the project setup" },
+          { role: "assistant", content: "The project uses TypeScript with vitest for testing" },
+          { role: "user", content: "Second question about dependencies" },
+          { role: "assistant", content: "We use Neo4j for the graph database backend" },
+          { role: "user", content: "Continue where we left off with the migration plan" },
+        ],
+      });
+
+      expect(result.systemPromptAddition).toBeDefined();
+      expect(result.systemPromptAddition).toContain("<graphiti-continuity>");
+      expect(result.systemPromptAddition).toContain("migration");
+    });
+
+    test("no session file — skips continuity block, still runs semantic", async () => {
+      const engine = createEngine();
+      // Bootstrap WITHOUT session file
+      await engine.bootstrap({ sessionId: "sess-1" });
+
+      const result = await engine.assemble({
+        sessionId: "sess-1",
+        messages: [{ role: "user", content: "Tell me about Alice" }],
+      });
+
+      expect(result.systemPromptAddition).toBeDefined();
+      // No continuity block since no session file
+      expect(result.systemPromptAddition).not.toContain("<graphiti-continuity>");
+      // Semantic block should still be present
+      expect(result.systemPromptAddition).toContain("<graphiti-context>");
+    });
+
+    test("one-shot: _lastEvent cleared after first recovery", async () => {
+      const sessionFile = createSessionFile([
+        { role: "user", content: "Previous conversation about the system design" },
+        { role: "assistant", content: "The system uses event-driven architecture with plugins" },
+      ]);
+
+      const engine = createEngine();
+      await engine.bootstrap({ sessionId: "sess-1", sessionFile });
+
+      // First assemble — bootstrap event triggers recovery
+      const result1 = await engine.assemble({
+        sessionId: "sess-1",
+        messages: [{ role: "user", content: "Tell me about Alice" }],
+      });
+      expect(result1.systemPromptAddition).toBeDefined();
+      expect(result1.systemPromptAddition).toContain("<graphiti-continuity>");
+
+      // Second assemble with few messages but no event — gap by message count still works
+      const result2 = await engine.assemble({
+        sessionId: "sess-1",
+        messages: [{ role: "user", content: "What else is there?" }],
+      });
+      // Still fires because messageCount <= 3 (gap heuristic), but no event flag
+      expect(result2.systemPromptAddition).toBeDefined();
+    });
+
+    test("fires after compact", async () => {
+      const sessionFile = createSessionFile([
+        { role: "user", content: "Discussion about the authentication system redesign" },
+        { role: "assistant", content: "The new auth system will use JWT with refresh tokens" },
+      ]);
+
+      const engine = createEngine();
+      await engine.bootstrap({ sessionId: "sess-1", sessionFile });
+
+      // Consume bootstrap event
+      await engine.assemble({
+        sessionId: "sess-1",
+        messages: [{ role: "user", content: "First question after bootstrap" }],
+      });
+
+      // Compact
+      await engine.compact({
+        sessionId: "sess-1",
+        messages: [
+          { role: "user", content: "Some messages being compacted from the conversation" },
+          { role: "assistant", content: "Responses that were part of the compacted segment" },
+        ],
+      });
+
+      // Next assemble after compact should trigger recovery
+      const result = await engine.assemble({
+        sessionId: "sess-1",
+        messages: [{ role: "user", content: "What were we discussing about auth?" }],
+      });
+
+      expect(result.systemPromptAddition).toBeDefined();
+      expect(result.systemPromptAddition).toContain("<graphiti-continuity>");
+      expect(result.systemPromptAddition).toContain("authentication");
+    });
+
+    test("afterTurn keeps session file reference fresh", async () => {
+      const engine = createEngine();
+      await engine.bootstrap({ sessionId: "sess-1" });
+
+      // Consume bootstrap event
+      await engine.assemble({
+        sessionId: "sess-1",
+        messages: [{ role: "user", content: "First question after bootstrap" }],
+      });
+
+      // afterTurn provides the session file
+      const sessionFile = createSessionFile([
+        { role: "user", content: "Important context about the API redesign project" },
+        { role: "assistant", content: "The API will use GraphQL instead of REST endpoints" },
+      ]);
+
+      await engine.afterTurn({
+        sessionId: "sess-1",
+        sessionFile,
+        messages: [
+          { role: "user", content: "New question about the project architecture and design" },
+          { role: "assistant", content: "New answer about the system patterns and conventions" },
+        ],
+        prePromptMessageCount: 0,
+      });
+
+      // Compact to trigger recovery on next assemble
+      await engine.compact({
+        sessionId: "sess-1",
+        messages: [
+          { role: "user", content: "Messages being compacted from the session history" },
+          { role: "assistant", content: "Responses included in the compaction cycle" },
+        ],
+      });
+
+      const result = await engine.assemble({
+        sessionId: "sess-1",
+        messages: [{ role: "user", content: "What about the API?" }],
+      });
+
+      expect(result.systemPromptAddition).toBeDefined();
+      expect(result.systemPromptAddition).toContain("<graphiti-continuity>");
+      expect(result.systemPromptAddition).toContain("GraphQL");
+    });
+
+    test("session file with only metadata and no messages returns semantic-only", async () => {
+      const filePath = path.join(tmpDir, "empty-session.jsonl");
+      const lines = [
+        JSON.stringify({ type: "session", version: 2, id: "test" }),
+        JSON.stringify({ type: "custom", customType: "model-snapshot", data: {} }),
+      ];
+      require("node:fs").writeFileSync(filePath, lines.join("\n"));
+
+      const engine = createEngine();
+      await engine.bootstrap({ sessionId: "sess-1", sessionFile: filePath });
+
+      const result = await engine.assemble({
+        sessionId: "sess-1",
+        messages: [{ role: "user", content: "Tell me about Alice" }],
+      });
+
+      expect(result.systemPromptAddition).toBeDefined();
+      expect(result.systemPromptAddition).not.toContain("<graphiti-continuity>");
+      expect(result.systemPromptAddition).toContain("<graphiti-context>");
+    });
+  });
+
+  // ========================================================================
+  // isContinuityGap (unit tests)
+  // ========================================================================
+
+  describe("isContinuityGap", () => {
+    test("returns true for messageCount below threshold", () => {
+      expect(isContinuityGap(0)).toBe(true);
+      expect(isContinuityGap(1)).toBe(true);
+      expect(isContinuityGap(2)).toBe(true);
+      expect(isContinuityGap(3)).toBe(true);
+    });
+
+    test("returns false for messageCount above threshold", () => {
+      expect(isContinuityGap(4)).toBe(false);
+      expect(isContinuityGap(10)).toBe(false);
+    });
+
+    test("returns true for bootstrap event regardless of count", () => {
+      expect(isContinuityGap(100, { recentEvent: "bootstrap" })).toBe(true);
+    });
+
+    test("returns true for compact event regardless of count", () => {
+      expect(isContinuityGap(100, { recentEvent: "compact" })).toBe(true);
+    });
+
+    test("respects custom threshold", () => {
+      expect(isContinuityGap(5, { threshold: 5 })).toBe(true);
+      expect(isContinuityGap(6, { threshold: 5 })).toBe(false);
+    });
+
+    test("null recentEvent does not trigger", () => {
+      expect(isContinuityGap(10, { recentEvent: null })).toBe(false);
+    });
+  });
+
+  // ========================================================================
+  // hasDeicticReferences (unit tests)
+  // ========================================================================
+
+  describe("hasDeicticReferences", () => {
+    test("detects 'as I mentioned'", () => {
+      expect(hasDeicticReferences("As I mentioned earlier, the API needs refactoring")).toBe(true);
+    });
+
+    test("detects 'continue'", () => {
+      expect(hasDeicticReferences("continue with the implementation")).toBe(true);
+    });
+
+    test("detects 'where we left off'", () => {
+      expect(hasDeicticReferences("pick up where we left off")).toBe(true);
+    });
+
+    test("detects 'that approach'", () => {
+      expect(hasDeicticReferences("let's use that approach")).toBe(true);
+    });
+
+    test("detects 'go on'", () => {
+      expect(hasDeicticReferences("go on with the plan")).toBe(true);
+    });
+
+    test("detects 'back to the'", () => {
+      expect(hasDeicticReferences("back to the original question")).toBe(true);
+    });
+
+    test("does not match normal prompts", () => {
+      expect(hasDeicticReferences("What is the architecture of this system?")).toBe(false);
+      expect(hasDeicticReferences("Write a function to parse JSON")).toBe(false);
+      expect(hasDeicticReferences("How do I deploy to production?")).toBe(false);
+    });
+  });
+
+  // ========================================================================
+  // readSessionFileTail (unit tests)
+  // ========================================================================
+
+  describe("readSessionFileTail", () => {
+    let tmpDir: string;
+
+    beforeEach(async () => {
+      tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "graphiti-session-tail-"));
+    });
+
+    afterEach(async () => {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    });
+
+    test("reads user and assistant messages from JSONL", async () => {
+      const filePath = path.join(tmpDir, "session.jsonl");
+      const lines = [
+        JSON.stringify({ type: "session", version: 2, id: "test" }),
+        JSON.stringify({ type: "message", message: { role: "user", content: "Hello world" } }),
+        JSON.stringify({ type: "message", message: { role: "assistant", content: "Hi there, how can I help?" } }),
+      ];
+      await fs.writeFile(filePath, lines.join("\n"));
+
+      const result = await readSessionFileTail(filePath);
+      expect(result).toBe("User: Hello world\nAssistant: Hi there, how can I help?");
+    });
+
+    test("skips non-message entries", async () => {
+      const filePath = path.join(tmpDir, "session.jsonl");
+      const lines = [
+        JSON.stringify({ type: "session", version: 2, id: "test" }),
+        JSON.stringify({ type: "custom", customType: "model-snapshot", data: {} }),
+        JSON.stringify({ type: "message", message: { role: "user", content: "What about the plan?" } }),
+        JSON.stringify({ type: "custom", customType: "tool-result", data: {} }),
+        JSON.stringify({ type: "message", message: { role: "assistant", content: "Here is the plan overview." } }),
+      ];
+      await fs.writeFile(filePath, lines.join("\n"));
+
+      const result = await readSessionFileTail(filePath);
+      expect(result).toBe("User: What about the plan?\nAssistant: Here is the plan overview.");
+    });
+
+    test("respects maxChars budget", async () => {
+      const filePath = path.join(tmpDir, "session.jsonl");
+      const lines = [
+        JSON.stringify({ type: "session", version: 2, id: "test" }),
+        JSON.stringify({ type: "message", message: { role: "user", content: "First message ".repeat(100) } }),
+        JSON.stringify({ type: "message", message: { role: "assistant", content: "Second message ".repeat(100) } }),
+        JSON.stringify({ type: "message", message: { role: "user", content: "Last message" } }),
+      ];
+      await fs.writeFile(filePath, lines.join("\n"));
+
+      const result = await readSessionFileTail(filePath, 100);
+      expect(result).not.toBeNull();
+      // Should only contain the last message(s) that fit within budget
+      expect(result!).toContain("Last message");
+      expect(result!.length).toBeLessThanOrEqual(200); // some slack for formatting
+    });
+
+    test("returns null for missing file", async () => {
+      const result = await readSessionFileTail("/nonexistent/path/session.jsonl");
+      expect(result).toBeNull();
+    });
+
+    test("returns null for file with no messages", async () => {
+      const filePath = path.join(tmpDir, "empty.jsonl");
+      const lines = [
+        JSON.stringify({ type: "session", version: 2, id: "test" }),
+        JSON.stringify({ type: "custom", customType: "model-snapshot", data: {} }),
+      ];
+      await fs.writeFile(filePath, lines.join("\n"));
+
+      const result = await readSessionFileTail(filePath);
+      expect(result).toBeNull();
+    });
+
+    test("skips system and tool role messages", async () => {
+      const filePath = path.join(tmpDir, "session.jsonl");
+      const lines = [
+        JSON.stringify({ type: "message", message: { role: "system", content: "You are a helpful assistant" } }),
+        JSON.stringify({ type: "message", message: { role: "user", content: "Hello world friend" } }),
+        JSON.stringify({ type: "message", message: { role: "tool", content: "Tool output result" } }),
+        JSON.stringify({ type: "message", message: { role: "assistant", content: "Hi there, how can I help you?" } }),
+      ];
+      await fs.writeFile(filePath, lines.join("\n"));
+
+      const result = await readSessionFileTail(filePath);
+      expect(result).toBe("User: Hello world friend\nAssistant: Hi there, how can I help you?");
+    });
+  });
+
+  // ========================================================================
+  // formatContinuityBlock (unit tests)
+  // ========================================================================
+
+  describe("formatContinuityBlock", () => {
+    test("wraps text in graphiti-continuity tags", () => {
+      const result = formatContinuityBlock("User: Hello\nAssistant: Hi");
+      expect(result).toBe("<graphiti-continuity>\nRecent session context (recovered from transcript):\nUser: Hello\nAssistant: Hi\n</graphiti-continuity>");
     });
   });
 });

--- a/test/context-engine.test.ts
+++ b/test/context-engine.test.ts
@@ -30,7 +30,7 @@ const PKG_VERSION: string = (_require("../package.json") as any).version;
 function createEngine() {
   const port = getMockPort();
   const client = new GraphitiClient(`http://127.0.0.1:${port}`, "test-group", undefined, undefined, NOOP_LOG);
-  return new GraphitiContextEngine(client, { recallMaxFacts: 10 }, "test-group", NOOP_LOG);
+  return new GraphitiContextEngine(client, { recallMaxFacts: 10, autoRecall: true }, "test-group", NOOP_LOG);
 }
 
 function createEngineWithConfig(cfg: Record<string, unknown>) {
@@ -1352,6 +1352,37 @@ describe("GraphitiContextEngine", () => {
       // /search should be used (driven by episode content), not /get-memory
       expect(lastRequest["/search"]).toBeDefined();
     });
+
+    test("autoRecall: false disables recall in assemble but engine still works", async () => {
+      const engine = createEngineWithConfig({ autoRecall: false });
+      await engine.bootstrap({ sessionId: "sess-1" });
+
+      const result = await engine.assemble({
+        sessionId: "sess-1",
+        messages: [{ role: "user", content: "Where were we?" }],
+      });
+
+      // assemble should return pass-through — no recall injection
+      expect(result.systemPromptAddition).toBeUndefined();
+      expect(lastRequest["/search"]).toBeUndefined();
+      expect(lastRequest["/get-memory"]).toBeUndefined();
+    });
+
+    test("autoRecall: false still allows capture via afterTurn", async () => {
+      const engine = createEngineWithConfig({ autoRecall: false, autoCapture: true });
+      await engine.bootstrap({ sessionId: "sess-1" });
+
+      await engine.afterTurn({
+        sessionId: "sess-1",
+        messages: [
+          { role: "user", content: "Tell me about the deployment pipeline and its stages" },
+          { role: "assistant", content: "The pipeline uses Docker containers with GitHub Actions for CI/CD" },
+        ],
+      });
+
+      // Capture should still work even with recall disabled
+      expect(lastRequest["/messages"]).toBeDefined();
+    });
   });
 
   // ========================================================================
@@ -1587,6 +1618,18 @@ describe("GraphitiContextEngine", () => {
       ];
       const result = extractEpisodeContinuity(episodes, "s1");
       expect(result).toBe("valid content");
+    });
+
+    test("cross-session thread_id does not leak content", () => {
+      const episodes = [
+        // Different session but same thread_id — should NOT be included
+        { source_description: JSON.stringify({ session_key: "other-session", thread_id: "t1" }), content: "secret from other session", created_at: "2024-01-15T12:00:00Z" },
+        // Matching session, no thread_id — should be included
+        { source_description: JSON.stringify({ session_key: "my-session" }), content: "my session content", created_at: "2024-01-15T11:00:00Z" },
+      ];
+      const result = extractEpisodeContinuity(episodes, "my-session", { threadId: "t1" });
+      expect(result).toBe("my session content");
+      expect(result).not.toContain("secret from other session");
     });
   });
 

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -51,6 +51,52 @@ export const SAMPLE_EPISODES = [
   },
 ];
 
+export const SAMPLE_EPISODES_WITH_SESSION = [
+  {
+    uuid: "ep-sess-001",
+    name: "turn-sess-1-1700000001",
+    group_id: "test-group",
+    created_at: "2024-01-15T11:00:00+00:00",
+    source: "message",
+    source_description: JSON.stringify({
+      plugin: "openclaw-graphiti",
+      event: "after_turn",
+      session_key: "sess-1",
+      group_id: "test-group",
+    }),
+    content: "user: What is the architecture of our system?\n\nassistant: The system uses microservices with Neo4j for the knowledge graph.",
+  },
+  {
+    uuid: "ep-sess-002",
+    name: "turn-other-1700000002",
+    group_id: "test-group",
+    created_at: "2024-01-15T10:00:00+00:00",
+    source: "message",
+    source_description: JSON.stringify({
+      plugin: "openclaw-graphiti",
+      event: "after_turn",
+      session_key: "other-session",
+      group_id: "test-group",
+    }),
+    content: "user: Unrelated conversation from another session.\n\nassistant: Different topic entirely.",
+  },
+  {
+    uuid: "ep-sess-003",
+    name: "turn-sess-1-thread-a-1700000003",
+    group_id: "test-group",
+    created_at: "2024-01-15T11:30:00+00:00",
+    source: "message",
+    source_description: JSON.stringify({
+      plugin: "openclaw-graphiti",
+      event: "after_turn",
+      session_key: "sess-1",
+      thread_id: "thread-a",
+      group_id: "test-group",
+    }),
+    content: "user: Tell me about the deployment pipeline.\n\nassistant: We use GitHub Actions with Docker containers.",
+  },
+];
+
 // ============================================================================
 // Mock HTTP Server
 // ============================================================================
@@ -58,6 +104,7 @@ export const SAMPLE_EPISODES = [
 export type MockOverrides = {
   healthy?: boolean;
   searchFacts?: GraphitiFact[];
+  getMemoryFacts?: GraphitiFact[];
   ingestStatus?: number;
   ingestBody?: Record<string, unknown>;
   searchStatus?: number;
@@ -163,7 +210,7 @@ export function startMockServer(): Promise<void> {
         res.writeHead(200, { "Content-Type": "application/json" });
         res.end(
           JSON.stringify({
-            facts: mockOverrides.searchFacts ?? SAMPLE_FACTS,
+            facts: mockOverrides.getMemoryFacts ?? mockOverrides.searchFacts ?? SAMPLE_FACTS,
           }),
         );
         return;

--- a/test/sanitize.test.ts
+++ b/test/sanitize.test.ts
@@ -106,4 +106,14 @@ describe("sanitizeForCapture", () => {
     const input = "  \n\nhello\n\n  ";
     expect(sanitizeForCapture(input)).toBe("hello");
   });
+
+  test("strips <graphiti-continuity> blocks", () => {
+    const input = "before\n<graphiti-continuity>\nRecent session context:\nUser: hello\nAssistant: hi\n</graphiti-continuity>\nafter";
+    expect(sanitizeForCapture(input)).toBe("before\n\nafter");
+  });
+
+  test("strips multiline <graphiti-continuity> blocks", () => {
+    const input = "<graphiti-continuity>\nRecent session context (recovered from transcript):\nUser: What about the plan?\nAssistant: We discussed the architecture.\n</graphiti-continuity>";
+    expect(sanitizeForCapture(input)).toBe("");
+  });
 });


### PR DESCRIPTION
## Summary

- **Two-stage continuity-aware `assemble()`**: replaces always-on semantic recall with a pipeline that only fires when context loss is detected
- **Stage A — session file recovery**: reads the tail of the JSONL session transcript (bounded 128KB chunk) to recover what was actually discussed
- **Stage B — targeted semantic search**: uses recovered continuity text as the `/search` query, so facts are relevant to the prior conversation — not to the possibly-empty current message window
- **Smart trigger conditions**: fires on continuity gaps (bootstrap, compaction, ≤3 messages) and deictic references ("continue", "as I mentioned", "where we left off"). Normal turns with sufficient history get zero auto-injection
- **Separate output blocks**: `<graphiti-continuity>` for transcript recovery, `<graphiti-context>` for semantic facts — aids debugging and prevents feedback loops via `sanitizeForCapture()`
- **Provenance scaffolding**: `thread_id` field added to `SessionMeta` and `buildProvenance()` for future saga support (#155)
- **Bonus cleanup**: legacy hooks `before_agent_start` now uses shared `formatFactsAsContext()` instead of inline formatting

## Test plan

- [x] All 254 tests pass (`npm test`) — 35 new tests
- [x] Smart autoRecall integration: bootstrap → continuity + semantic blocks
- [x] No injection on normal turns with sufficient messages
- [x] Deictic trigger fires even with many messages
- [x] No session file → semantic-only fallback
- [x] One-shot: `_lastEvent` cleared after first recovery
- [x] Compact triggers recovery on next assemble
- [x] `afterTurn` keeps session file reference fresh
- [x] `isContinuityGap`, `hasDeicticReferences`, `readSessionFileTail` unit tests
- [x] `<graphiti-continuity>` stripped by `sanitizeForCapture()`
- [ ] Manual: `/compact` or `/new` → send "continue where we left off" → verify both blocks appear
- [ ] Manual: normal mid-conversation turn → verify no auto-injection

Closes #164