### PR TITLE
fix: OpenClaw 3.28 compatibility pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## [Unreleased]
 
+### Changed
+
+- **SDK import modernisation**: migrated type import from root `openclaw/plugin-sdk`
+  to narrow subpath `openclaw/plugin-sdk/plugin-entry`; removed `(api as any)` casts
+  on `registerContextEngine` (now typed on `OpenClawPluginApi`).
+- **Published package metadata**: `README.md` and `skills/` are now included in the
+  npm tarball via the `files[]` array.
+- **Plugin manifest**: added `"skills": ["./skills"]` for agent skill discovery.
+
+### Added
+
+- **SKILL.md**: new `skills/graphiti/SKILL.md` with tool reference table, usage
+  guidance, and memory-core complementarity notes.
+- **Install guidance**: README now documents stable (pinned version) vs beta
+  (`@beta` tag) install paths.
+
 ### Added
 
 - **Smart autoRecall** (#164): `assemble()` is now a two-stage continuity-aware

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,24 +2,12 @@
 
 ## [Unreleased]
 
-### Changed
-
-- **SDK import modernisation**: migrated type import from root `openclaw/plugin-sdk`
-  to narrow subpath `openclaw/plugin-sdk/plugin-entry`; removed `(api as any)` casts
-  on `registerContextEngine` (now typed on `OpenClawPluginApi`).
-- **Published package metadata**: `README.md` and `skills/` are now included in the
-  npm tarball via the `files[]` array.
-- **Plugin manifest**: added `"skills": ["./skills"]` for agent skill discovery.
-
 ### Added
 
 - **SKILL.md**: new `skills/graphiti/SKILL.md` with tool reference table, usage
   guidance, and memory-core complementarity notes.
 - **Install guidance**: README now documents stable (pinned version) vs beta
   (`@beta` tag) install paths.
-
-### Added
-
 - **Smart autoRecall** (#164): `assemble()` is now a two-stage continuity-aware
   pipeline that only fires when context loss is detected — not every turn.
   - **Stage A** reads the tail of the JSONL session transcript (bounded 128KB chunk)
@@ -54,6 +42,12 @@
 
 ### Changed
 
+- **SDK import modernisation**: migrated type import from root `openclaw/plugin-sdk`
+  to narrow subpath `openclaw/plugin-sdk/plugin-entry`; removed `(api as any)` casts
+  on `registerContextEngine` (now typed on `OpenClawPluginApi`).
+- **Published package metadata**: `README.md` and `skills/` are now included in the
+  npm tarball via the `files[]` array.
+- **Plugin manifest**: added `"skills": ["./skills"]` for agent skill discovery.
 - Legacy hooks `before_agent_start` now uses shared `formatFactsAsContext()`
   instead of inline fact formatting.
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,24 @@ ln -s /path/to/openclaw-graphiti-plugin ~/.openclaw/extensions/graphiti
 
 The plugin declares `openclaw.extensions` in `package.json`, so OpenClaw discovers it automatically from `~/.openclaw/extensions/`.
 
+### Stable vs beta
+
+For production use, pin to an exact version:
+
+```bash
+openclaw plugins install @robertogongora/graphiti@0.7.0
+```
+
+For development or early access to unreleased features:
+
+```bash
+openclaw plugins install @robertogongora/graphiti@beta
+```
+
+The `@beta` tag resolves to the latest pre-release at install time. The resolved
+version is locked, but future `openclaw plugins update` runs will pull the newest
+beta. For reproducible deployments, always use an exact version.
+
 ## Recommended setup
 
 As of v0.3.0, Graphiti does **not** claim the exclusive memory slot. The recommended

--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ The plugin declares `openclaw.extensions` in `package.json`, so OpenClaw discove
 
 ### Stable vs beta
 
-For production use, pin to an exact version:
+For production use, pin to an exact stable version:
 
 ```bash
-openclaw plugins install @robertogongora/graphiti@0.7.0
+openclaw plugins install @robertogongora/graphiti@<stable-version>
 ```
 
 For development or early access to unreleased features:

--- a/context-engine.ts
+++ b/context-engine.ts
@@ -15,8 +15,9 @@ const _require = createRequire(import.meta.url);
 const PLUGIN_VERSION: string = (_require("./package.json") as any).version;
 
 // ---------------------------------------------------------------------------
-// Types from openclaw/plugin-sdk — declared locally so the plugin compiles
-// without a hard dependency on a specific OpenClaw version.
+// Types from openclaw/plugin-sdk (canonical source: context-engine/types.ts).
+// Declared locally so the plugin compiles without a hard dependency on a
+// specific OpenClaw version. Keep structurally compatible with the SDK types.
 // ---------------------------------------------------------------------------
 
 export interface ContextEngineInfo {

--- a/index.ts
+++ b/index.ts
@@ -415,6 +415,8 @@ const graphitiPlugin = {
       api.registerContextEngine("graphiti", () =>
         new GraphitiContextEngine(client, cfg, groupId, debugLog, api.logger),
       );
+    } else {
+      debugLog.log("register", { contextEngine: false, reason: "api_version" });
     }
 
     // ========================================================================

--- a/index.ts
+++ b/index.ts
@@ -15,7 +15,7 @@
  * - Slash command: /graphiti
  */
 
-import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
 import { Type } from "@sinclair/typebox";
 import path from "node:path";
 import os from "node:os";
@@ -409,10 +409,10 @@ const graphitiPlugin = {
     // ContextEngine registration (OpenClaw v2026.3.7+)
     // ========================================================================
 
-    const hasEngineSupport = typeof (api as any).registerContextEngine === "function";
+    const hasEngineSupport = typeof api.registerContextEngine === "function";
 
     if (hasEngineSupport) {
-      (api as any).registerContextEngine("graphiti", () =>
+      api.registerContextEngine("graphiti", () =>
         new GraphitiContextEngine(client, cfg, groupId, debugLog, api.logger),
       );
     }

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,6 +1,7 @@
 {
   "kind": "context-engine",
   "id": "graphiti",
+  "skills": ["./skills"],
   "name": "Graphiti Knowledge Graph",
   "description": "Temporal knowledge graph for persistent agent memory. Auto-recalls relevant facts before each conversation and captures knowledge after.",
   "configSchema": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,9 @@
     "shared.ts",
     "debug-log.ts",
     "memory-index.ts",
-    "openclaw.plugin.json"
+    "openclaw.plugin.json",
+    "README.md",
+    "skills"
   ],
   "scripts": {
     "test": "vitest run"

--- a/skills/graphiti/SKILL.md
+++ b/skills/graphiti/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: graphiti
 description: Temporal knowledge graph — search facts and relationships, ingest knowledge, manage episodes, and forget outdated information.
+trigger: graphiti, knowledge graph, graph memory, ingest episodes, search facts, remember this, what do we know about, relationship between
 ---
 
 # Graphiti Knowledge Graph

--- a/skills/graphiti/SKILL.md
+++ b/skills/graphiti/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: graphiti
+description: Temporal knowledge graph — search facts and relationships, ingest knowledge, manage episodes, and forget outdated information.
+---
+
+# Graphiti Knowledge Graph
+
+Use these tools to interact with the Graphiti temporal knowledge graph. Graphiti extracts entities and relationships from conversations and stores them in a Neo4j graph database for long-term retrieval.
+
+## Tools
+
+| Tool | When to use |
+|------|-------------|
+| `graphiti_search` | Find facts, entities, and relationships — "What do I know about X?", "What's the relationship between X and Y?", "What was the history of project X?" |
+| `graphiti_ingest` | Manually store important information the user wants remembered long-term |
+| `graphiti_forget` | Remove outdated, incorrect, or superseded facts from the graph |
+| `graphiti_episodes` | Browse recently ingested episodes — useful for checking what was captured |
+
+## Complementing memory-core
+
+This plugin works alongside `memory-core`, not as a replacement:
+
+- **memory-core** (`memory_search`) — searches workspace Markdown files in `memory/`
+- **Graphiti** (`graphiti_search`) — searches extracted entities, relationships, and temporal facts from conversations
+
+Use `memory_search` for "what did I write in my notes?" and `graphiti_search` for "what do I know about the relationship between X and Y?" or "what was discussed about X over time?"
+
+## Requirements
+
+- Graphiti server must be running (default: `http://localhost:8100`)
+- Neo4j database (managed by Graphiti)

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -31,6 +31,35 @@ describe("plugin shape", () => {
 });
 
 // ============================================================================
+// Manifest & Packaging
+// ============================================================================
+
+describe("manifest and packaging contract", () => {
+  test("manifest declares skills", async () => {
+    const fs = await import("node:fs");
+    const manifest = JSON.parse(
+      fs.readFileSync(new URL("../openclaw.plugin.json", import.meta.url), "utf-8"),
+    );
+    expect(manifest.skills).toEqual(["./skills"]);
+  });
+
+  test("SKILL.md exists at the declared path", async () => {
+    const fs = await import("node:fs");
+    const skillPath = new URL("../skills/graphiti/SKILL.md", import.meta.url);
+    expect(fs.existsSync(skillPath)).toBe(true);
+  });
+
+  test("package.json files[] includes README.md and skills", async () => {
+    const fs = await import("node:fs");
+    const pkg = JSON.parse(
+      fs.readFileSync(new URL("../package.json", import.meta.url), "utf-8"),
+    );
+    expect(pkg.files).toContain("README.md");
+    expect(pkg.files).toContain("skills");
+  });
+});
+
+// ============================================================================
 // Registration
 // ============================================================================
 


### PR DESCRIPTION
## Summary

- **SDK import**: migrated from root `openclaw/plugin-sdk` to modern subpath `openclaw/plugin-sdk/plugin-entry`; removed `(api as any)` casts on `registerContextEngine` (now typed on `OpenClawPluginApi`)
- **SKILL.md**: created `skills/graphiti/SKILL.md` with tool reference table and usage guidance; added `"skills"` field to plugin manifest
- **Package metadata**: added `README.md` and `skills/` to `files[]` so they ship in the published npm package
- **Install guidance**: added "Stable vs beta" section to README documenting pinned-version vs `@beta` tag install

## Test plan

- [x] All 272 existing tests pass
- [x] `npm pack --dry-run` confirms README.md and skills/graphiti/SKILL.md are included in tarball
- [ ] Manual: install packed tarball into OpenClaw v2026.3.28 and verify plugin loads, context engine registers, tools work

Closes #166