### PR TITLE
feat: short-circuit recall after first Graphiti injection per session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@
   (bootstrap, compaction) and deictic references override the gate so recovery
   still fires when needed. Eliminates per-turn prompt churn and improves
   prompt-cache reuse.
+  - `afterTurn()` now detects auto-compaction (message window shrunk mid-prompt)
+    and clears the recall gate so the next `assemble()` fires recovery.
+  - The 1000-entry safety cap on `_recalledSessions` now emits a debug log when
+    it triggers.
+  - Internal lifecycle state management extracted into `signalRecovery()` and
+    typed with `LifecycleEvent` union (`"bootstrap" | "compact"`).
 - **Smart autoRecall** (#164): `assemble()` is now a two-stage continuity-aware
   pipeline that only fires when context loss is detected — not every turn.
   - **Stage A** reads the tail of the JSONL session transcript (bounded 128KB chunk)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@
   guidance, and memory-core complementarity notes.
 - **Install guidance**: README now documents stable (pinned version) vs beta
   (`@beta` tag) install paths.
+- **Session-scoped recall short-circuit** (#168): `assemble()` now skips recall
+  after the first successful Graphiti injection per session. Lifecycle events
+  (bootstrap, compaction) and deictic references override the gate so recovery
+  still fires when needed. Eliminates per-turn prompt churn and improves
+  prompt-cache reuse.
 - **Smart autoRecall** (#164): `assemble()` is now a two-stage continuity-aware
   pipeline that only fires when context loss is detected — not every turn.
   - **Stage A** reads the tail of the JSONL session transcript (bounded 128KB chunk)

--- a/context-engine.ts
+++ b/context-engine.ts
@@ -91,6 +91,7 @@ export class GraphitiContextEngine {
   private _sessionFile: string | null = null;
   private _sessionId: string | null = null;
   private _threadId: string | null = null;
+  private _recalledSessions = new Set<string>();
 
   constructor(
     private client: GraphitiClient,
@@ -208,6 +209,17 @@ export class GraphitiContextEngine {
       const gapDetected = isContinuityGap(params.messages.length, { recentEvent: this._lastEvent });
       const deicticDetected = !!lastUserText && hasDeicticReferences(lastUserText);
 
+      // Session-scoped short-circuit: skip recall if this session already received
+      // Graphiti context.  Lifecycle events (bootstrap/compact via _lastEvent) and
+      // deictic references override the gate so recovery still fires when needed.
+      // TODO: if the plugin-sdk exposes effective system-prompt contents or
+      // placement control for ContextEngine additions, replace this session-scoped
+      // short-circuit with direct Graphiti-tag detection or append-based placement.
+      if (this._recalledSessions.has(params.sessionId) && !this._lastEvent && !deicticDetected) {
+        this.debugLog.log("ce-assemble", { skipped: true, reason: "already_injected" });
+        return passThrough;
+      }
+
       if (!gapDetected && !deicticDetected) {
         this.debugLog.log("ce-assemble", { skipped: true, reason: "no_recovery_needed" });
         return passThrough;
@@ -281,6 +293,8 @@ export class GraphitiContextEngine {
         ms: Date.now() - start,
       });
 
+      if (this._recalledSessions.size >= 1000) this._recalledSessions.clear();
+      this._recalledSessions.add(params.sessionId);
       return { messages: params.messages, systemPromptAddition, estimatedTokens };
     } catch (err) {
       this.logger?.warn(`graphiti: assemble failed: ${String(err)}`);
@@ -371,12 +385,14 @@ export class GraphitiContextEngine {
         }]);
 
         this._lastEvent = "compact";
+        this._recalledSessions.delete(params.sessionId);
         this.debugLog.log("ce-compact", { action: "ingested", texts: texts.length, compacted: true });
         return { ok: true, compacted: true };
       }
 
       if (params.legacyParams?.bridge) {
         this._lastEvent = "compact";
+        this._recalledSessions.delete(params.sessionId);
         this.debugLog.log("ce-compact", { action: "legacy_bridge" });
         await params.legacyParams.bridge.compact();
         return { ok: true, compacted: true };
@@ -554,6 +570,7 @@ export class GraphitiContextEngine {
       }
 
       this._lastEvent = "bootstrap";
+      this._recalledSessions.delete(params.sessionId);
 
       const stats = await this.client.episodeCount();
       this.debugLog.log("ce-bootstrap", { healthy: true, episodes: stats.count });

--- a/context-engine.ts
+++ b/context-engine.ts
@@ -10,6 +10,7 @@ import { createRequire } from "node:module";
 import type { GraphitiClient, GraphitiMessage } from "./client.js";
 import type { DebugLog } from "./debug-log.js";
 import { buildEpisodeName, buildProvenance, extractEpisodeContinuity, extractTextContent, extractTextsFromMessages, formatContinuityBlock, formatFactsAsContext, hasDeicticReferences, isContinuityGap, readSessionFileTail, sanitizeForCapture } from "./shared.js";
+import type { LifecycleEvent } from "./shared.js";
 
 const _require = createRequire(import.meta.url);
 const PLUGIN_VERSION: string = (_require("./package.json") as any).version;
@@ -87,7 +88,7 @@ export class GraphitiContextEngine {
   private static readonly HEALTH_CACHE_TTL_MS = 15_000;
 
   /** Smart autoRecall state — tracks lifecycle events for continuity gap detection. */
-  private _lastEvent: string | null = null;
+  private _lastEvent: LifecycleEvent | null = null;
   private _sessionFile: string | null = null;
   private _sessionId: string | null = null;
   private _threadId: string | null = null;
@@ -100,6 +101,12 @@ export class GraphitiContextEngine {
     private debugLog: DebugLog,
     private logger?: { info?: (...args: any[]) => void; warn: (...args: any[]) => void },
   ) {}
+
+  /** Signal that the next assemble() should fire recovery for this session. */
+  private signalRecovery(sessionId: string, event: LifecycleEvent): void {
+    this._lastEvent = event;
+    this._recalledSessions.delete(sessionId);
+  }
 
   /** Health check with short TTL cache (15s). */
   private async cachedHealthy(): Promise<boolean> {
@@ -212,7 +219,7 @@ export class GraphitiContextEngine {
       // Session-scoped short-circuit: skip recall if this session already received
       // Graphiti context.  Lifecycle events (bootstrap/compact via _lastEvent) and
       // deictic references override the gate so recovery still fires when needed.
-      // TODO: if the plugin-sdk exposes effective system-prompt contents or
+      // TODO(#171): if the plugin-sdk exposes effective system-prompt contents or
       // placement control for ContextEngine additions, replace this session-scoped
       // short-circuit with direct Graphiti-tag detection or append-based placement.
       if (this._recalledSessions.has(params.sessionId) && !this._lastEvent && !deicticDetected) {
@@ -225,7 +232,8 @@ export class GraphitiContextEngine {
         return passThrough;
       }
 
-      // Consume the one-shot event flag
+      // Consume the one-shot event flag.  Safe: JS is single-threaded so no
+      // concurrent assemble() can read between capture and clear.
       const triggerEvent = this._lastEvent;
       this._lastEvent = null;
       const maxFacts = this.cfg.recallMaxFacts ?? 10;
@@ -293,7 +301,10 @@ export class GraphitiContextEngine {
         ms: Date.now() - start,
       });
 
-      if (this._recalledSessions.size >= 1000) this._recalledSessions.clear();
+      if (this._recalledSessions.size >= 1000) {
+        this.debugLog.log("ce-assemble", { action: "recalled_sessions_reset", previousSize: this._recalledSessions.size });
+        this._recalledSessions.clear();
+      }
       this._recalledSessions.add(params.sessionId);
       return { messages: params.messages, systemPromptAddition, estimatedTokens };
     } catch (err) {
@@ -384,15 +395,13 @@ export class GraphitiContextEngine {
           source_description: buildProvenance(this.groupId, { event: "compact", session_key: params.sessionId, thread_id: this._threadId ?? undefined }),
         }]);
 
-        this._lastEvent = "compact";
-        this._recalledSessions.delete(params.sessionId);
+        this.signalRecovery(params.sessionId, "compact");
         this.debugLog.log("ce-compact", { action: "ingested", texts: texts.length, compacted: true });
         return { ok: true, compacted: true };
       }
 
       if (params.legacyParams?.bridge) {
-        this._lastEvent = "compact";
-        this._recalledSessions.delete(params.sessionId);
+        this.signalRecovery(params.sessionId, "compact");
         this.debugLog.log("ce-compact", { action: "legacy_bridge" });
         await params.legacyParams.bridge.compact();
         return { ok: true, compacted: true };
@@ -543,6 +552,13 @@ export class GraphitiContextEngine {
 
       this.logger?.info?.(`graphiti: after-turn ingested ${texts.length} messages`);
       this.debugLog.log("ce-afterTurn", { count: texts.length, sweep: compactionOccurred, ms: Date.now() - start });
+
+      // Auto-compaction truncated the message window — clear the session
+      // recall flag so the next assemble() fires recovery, mirroring the
+      // explicit compact() method.
+      if (compactionOccurred) {
+        this.signalRecovery(params.sessionId, "compact");
+      }
     } catch (err) {
       this.logger?.warn(`graphiti: afterTurn failed: ${String(err)}`);
       this.debugLog.log("ce-afterTurn", { error: String(err) });
@@ -569,8 +585,7 @@ export class GraphitiContextEngine {
         return { bootstrapped: false, reason: "server-unhealthy" };
       }
 
-      this._lastEvent = "bootstrap";
-      this._recalledSessions.delete(params.sessionId);
+      this.signalRecovery(params.sessionId, "bootstrap");
 
       const stats = await this.client.episodeCount();
       this.debugLog.log("ce-bootstrap", { healthy: true, episodes: stats.count });

--- a/shared.ts
+++ b/shared.ts
@@ -191,9 +191,11 @@ export function formatFactsAsContext(facts: { name: string; fact: string }[]): s
  * Detect whether the current turn is likely a continuity gap —
  * the runtime has lost recent conversational context.
  */
+export type LifecycleEvent = "bootstrap" | "compact";
+
 export function isContinuityGap(
   messageCount: number,
-  opts?: { recentEvent?: string | null; threshold?: number },
+  opts?: { recentEvent?: LifecycleEvent | string | null; threshold?: number },
 ): boolean {
   const threshold = opts?.threshold ?? 3;
   const event = opts?.recentEvent;

--- a/test/context-engine.test.ts
+++ b/test/context-engine.test.ts
@@ -17,6 +17,7 @@ import {
   mockOverrides,
   lastRequest,
   SAMPLE_EPISODES_WITH_SESSION,
+  SAMPLE_FACTS,
 } from "./helpers.js";
 import { GraphitiClient } from "../client.js";
 import { NOOP_LOG } from "../debug-log.js";
@@ -37,6 +38,16 @@ function createEngineWithConfig(cfg: Record<string, unknown>) {
   const port = getMockPort();
   const client = new GraphitiClient(`http://127.0.0.1:${port}`, "test-group", undefined, undefined, NOOP_LOG);
   return new GraphitiContextEngine(client, { recallMaxFacts: 10, ...cfg }, "test-group", NOOP_LOG);
+}
+
+function createSessionFile(dir: string, messages: Array<{ role: string; content: string }>): string {
+  const filePath = path.join(dir, "session.jsonl");
+  const lines = [
+    JSON.stringify({ type: "session", version: 2, id: "test-session", timestamp: new Date().toISOString() }),
+    ...messages.map((m) => JSON.stringify({ type: "message", message: { role: m.role, content: m.content } })),
+  ];
+  require("node:fs").writeFileSync(filePath, lines.join("\n"));
+  return filePath;
 }
 
 describe("GraphitiContextEngine", () => {
@@ -347,6 +358,45 @@ describe("GraphitiContextEngine", () => {
       expect(req).toBeDefined();
       expect(req.messages[0].source_description).toContain('"event":"after_turn"');
       expect(req.messages[0].source_description).not.toContain("after_turn_sweep");
+    });
+
+    test("auto-compaction clears recalled session for next assemble", async () => {
+      const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "graphiti-afterTurn-cap-"));
+      const sessionFile = createSessionFile(tmpDir, [
+        { role: "user", content: "Architecture discussion for auto-compact test" },
+        { role: "assistant", content: "The system uses plugin-based architecture design" },
+      ]);
+
+      try {
+        const engine = createEngine();
+        await engine.bootstrap({ sessionId: "sess-1", sessionFile });
+
+        // First assemble — marks session
+        const result1 = await engine.assemble({
+          sessionId: "sess-1",
+          messages: [{ role: "user", content: "Hello" }],
+        });
+        expect(result1.systemPromptAddition).toBeDefined();
+
+        // afterTurn with auto-compaction (prePromptMessageCount > messages.length)
+        await engine.afterTurn({
+          sessionId: "sess-1",
+          messages: [
+            { role: "user", content: "Question about the architecture and design patterns" },
+            { role: "assistant", content: "Response about the system architecture and design" },
+          ],
+          prePromptMessageCount: 10,
+        });
+
+        // Next assemble — should fire recovery because afterTurn cleared the flag
+        const result2 = await engine.assemble({
+          sessionId: "sess-1",
+          messages: [{ role: "user", content: "Continue" }],
+        });
+        expect(result2.systemPromptAddition).toBeDefined();
+      } finally {
+        await fs.rm(tmpDir, { recursive: true, force: true });
+      }
     });
   });
 
@@ -968,19 +1018,8 @@ describe("GraphitiContextEngine", () => {
       await fs.rm(tmpDir, { recursive: true, force: true });
     });
 
-    function createSessionFile(messages: Array<{ role: string; content: string }>): string {
-      const filePath = path.join(tmpDir, "session.jsonl");
-      const lines = [
-        JSON.stringify({ type: "session", version: 2, id: "test-session", timestamp: new Date().toISOString() }),
-        ...messages.map((m) => JSON.stringify({ type: "message", message: { role: m.role, content: m.content } })),
-      ];
-      // Write synchronously for simplicity in tests — file is small
-      require("node:fs").writeFileSync(filePath, lines.join("\n"));
-      return filePath;
-    }
-
     test("fires after bootstrap with session file — produces both continuity and semantic blocks", async () => {
-      const sessionFile = createSessionFile([
+      const sessionFile = createSessionFile(tmpDir, [
         { role: "user", content: "What is the architecture of the new feature?" },
         { role: "assistant", content: "The feature uses a modular plugin architecture with event-driven communication." },
         { role: "user", content: "How does the session file work?" },
@@ -1006,7 +1045,7 @@ describe("GraphitiContextEngine", () => {
     });
 
     test("does not fire when many messages and no deictic refs", async () => {
-      const sessionFile = createSessionFile([
+      const sessionFile = createSessionFile(tmpDir, [
         { role: "user", content: "Old conversation about something" },
         { role: "assistant", content: "Old response about the topic" },
       ]);
@@ -1036,7 +1075,7 @@ describe("GraphitiContextEngine", () => {
     });
 
     test("fires on deictic references even with sufficient messages", async () => {
-      const sessionFile = createSessionFile([
+      const sessionFile = createSessionFile(tmpDir, [
         { role: "user", content: "We were discussing the migration strategy for the database" },
         { role: "assistant", content: "The migration plan involves three phases with rollback support" },
       ]);
@@ -1085,7 +1124,7 @@ describe("GraphitiContextEngine", () => {
     });
 
     test("one-shot: _lastEvent cleared after first recovery", async () => {
-      const sessionFile = createSessionFile([
+      const sessionFile = createSessionFile(tmpDir, [
         { role: "user", content: "Previous conversation about the system design" },
         { role: "assistant", content: "The system uses event-driven architecture with plugins" },
       ]);
@@ -1110,7 +1149,7 @@ describe("GraphitiContextEngine", () => {
     });
 
     test("fires after compact", async () => {
-      const sessionFile = createSessionFile([
+      const sessionFile = createSessionFile(tmpDir, [
         { role: "user", content: "Discussion about the authentication system redesign" },
         { role: "assistant", content: "The new auth system will use JWT with refresh tokens" },
       ]);
@@ -1155,7 +1194,7 @@ describe("GraphitiContextEngine", () => {
       });
 
       // afterTurn provides the session file
-      const sessionFile = createSessionFile([
+      const sessionFile = createSessionFile(tmpDir, [
         { role: "user", content: "Important context about the API redesign project" },
         { role: "assistant", content: "The API will use GraphQL instead of REST endpoints" },
       ]);
@@ -1307,7 +1346,7 @@ describe("GraphitiContextEngine", () => {
 
     test("skips episode fetch when session file has content", async () => {
       mockOverrides.episodes = SAMPLE_EPISODES_WITH_SESSION;
-      const sessionFile = createSessionFile([
+      const sessionFile = createSessionFile(tmpDir, [
         { role: "user", content: "This is the existing session file content about React hooks" },
         { role: "assistant", content: "React hooks are used for state management and side effects." },
       ]);
@@ -1354,7 +1393,7 @@ describe("GraphitiContextEngine", () => {
 
     describe("session-scoped short-circuit", () => {
       test("first turn injects and marks session; second turn short-circuits", async () => {
-        const sessionFile = createSessionFile([
+        const sessionFile = createSessionFile(tmpDir, [
           { role: "user", content: "Tell me about the architecture" },
           { role: "assistant", content: "The system uses microservices with Neo4j" },
         ]);
@@ -1377,7 +1416,7 @@ describe("GraphitiContextEngine", () => {
       });
 
       test("second turn does not call /get-memory or /search", async () => {
-        const sessionFile = createSessionFile([
+        const sessionFile = createSessionFile(tmpDir, [
           { role: "user", content: "Previous discussion about deployment" },
           { role: "assistant", content: "Deployment uses Docker containers" },
         ]);
@@ -1419,9 +1458,9 @@ describe("GraphitiContextEngine", () => {
         });
         expect(result1.systemPromptAddition).toBeUndefined();
 
-        // Restore facts and trigger compact to set _lastEvent (messages must be >20 chars)
-        mockOverrides.searchFacts = undefined;
-        mockOverrides.getMemoryFacts = undefined;
+        // Restore default facts and trigger compact to set _lastEvent
+        mockOverrides.searchFacts = SAMPLE_FACTS;
+        mockOverrides.getMemoryFacts = SAMPLE_FACTS;
         await engine.compact({
           sessionId: "sess-1",
           messages: [
@@ -1439,7 +1478,7 @@ describe("GraphitiContextEngine", () => {
       });
 
       test("different sessionId still performs recall", async () => {
-        const sessionFile = createSessionFile([
+        const sessionFile = createSessionFile(tmpDir, [
           { role: "user", content: "Architecture discussion" },
           { role: "assistant", content: "Event-driven design with plugins" },
         ]);
@@ -1463,7 +1502,7 @@ describe("GraphitiContextEngine", () => {
       });
 
       test("compact overrides short-circuit", async () => {
-        const sessionFile = createSessionFile([
+        const sessionFile = createSessionFile(tmpDir, [
           { role: "user", content: "System design discussion" },
           { role: "assistant", content: "The system uses event-driven architecture" },
         ]);
@@ -1496,7 +1535,7 @@ describe("GraphitiContextEngine", () => {
       });
 
       test("deictic reference overrides short-circuit", async () => {
-        const sessionFile = createSessionFile([
+        const sessionFile = createSessionFile(tmpDir, [
           { role: "user", content: "Discuss the authentication redesign" },
           { role: "assistant", content: "JWT with refresh tokens for the new auth system" },
         ]);
@@ -1520,6 +1559,85 @@ describe("GraphitiContextEngine", () => {
           })),
         });
         expect(result2.systemPromptAddition).toBeDefined();
+      });
+
+      test("1000-entry cap clears Set and allows re-injection", async () => {
+        const sessionFile = createSessionFile(tmpDir, [
+          { role: "user", content: "Architecture discussion for cap testing" },
+          { role: "assistant", content: "The system uses event-driven design patterns" },
+        ]);
+
+        const engine = createEngine();
+        await engine.bootstrap({ sessionId: "sess-cap", sessionFile });
+
+        // Pre-fill _recalledSessions with 1000 entries so the cap fires on next add
+        const recalled = (engine as any)._recalledSessions as Set<string>;
+        for (let i = 0; i < 1000; i++) {
+          recalled.add(`filler-session-${i}`);
+        }
+        expect(recalled.size).toBe(1000);
+
+        // Mark the real session (hits 1000 → cap triggers: clear + re-add)
+        const result1 = await engine.assemble({
+          sessionId: "sess-cap",
+          messages: [{ role: "user", content: "Hello" }],
+        });
+        expect(result1.systemPromptAddition).toBeDefined();
+
+        // Cap should have triggered: Set cleared, then sess-cap re-added
+        expect(recalled.size).toBe(1);
+        expect(recalled.has("sess-cap")).toBe(true);
+
+        // A new session should still get recall
+        await engine.bootstrap({ sessionId: "sess-cap-2", sessionFile });
+        const result2 = await engine.assemble({
+          sessionId: "sess-cap-2",
+          messages: [{ role: "user", content: "Continue" }],
+        });
+        expect(result2.systemPromptAddition).toBeDefined();
+      });
+
+      test("session is re-marked after compact override — third assemble short-circuits", async () => {
+        const sessionFile = createSessionFile(tmpDir, [
+          { role: "user", content: "System design discussion about auth" },
+          { role: "assistant", content: "The system uses JWT with refresh tokens" },
+        ]);
+
+        const engine = createEngine();
+        await engine.bootstrap({ sessionId: "sess-1", sessionFile });
+
+        // 1st assemble — injects context, marks session
+        const result1 = await engine.assemble({
+          sessionId: "sess-1",
+          messages: [{ role: "user", content: "Hello" }],
+        });
+        expect(result1.systemPromptAddition).toBeDefined();
+
+        // Compact clears mark and sets _lastEvent
+        await engine.compact({
+          sessionId: "sess-1",
+          messages: [
+            { role: "user", content: "Tell me about the deployment pipeline and its stages" },
+            { role: "assistant", content: "The pipeline uses Docker containers with GitHub Actions for CI/CD" },
+          ],
+        });
+
+        // 2nd assemble — compact override fires, re-marks session
+        const result2 = await engine.assemble({
+          sessionId: "sess-1",
+          messages: [{ role: "user", content: "Where were we?" }],
+        });
+        expect(result2.systemPromptAddition).toBeDefined();
+
+        // 3rd assemble — session re-marked, should short-circuit
+        const result3 = await engine.assemble({
+          sessionId: "sess-1",
+          messages: Array.from({ length: 5 }, (_, i) => ({
+            role: i % 2 === 0 ? "user" : "assistant",
+            content: `msg ${i}`,
+          })),
+        });
+        expect(result3.systemPromptAddition).toBeUndefined();
       });
     });
 

--- a/test/context-engine.test.ts
+++ b/test/context-engine.test.ts
@@ -1101,13 +1101,12 @@ describe("GraphitiContextEngine", () => {
       expect(result1.systemPromptAddition).toBeDefined();
       expect(result1.systemPromptAddition).toContain("<graphiti-continuity>");
 
-      // Second assemble with few messages but no event — gap by message count still works
+      // Second assemble — session already recalled, short-circuits (bootstrap-once)
       const result2 = await engine.assemble({
         sessionId: "sess-1",
         messages: [{ role: "user", content: "What else is there?" }],
       });
-      // Still fires because messageCount <= 3 (gap heuristic), but no event flag
-      expect(result2.systemPromptAddition).toBeDefined();
+      expect(result2.systemPromptAddition).toBeUndefined();
     });
 
     test("fires after compact", async () => {
@@ -1351,6 +1350,177 @@ describe("GraphitiContextEngine", () => {
       expect(result.systemPromptAddition).toContain("microservices");
       // /search should be used (driven by episode content), not /get-memory
       expect(lastRequest["/search"]).toBeDefined();
+    });
+
+    describe("session-scoped short-circuit", () => {
+      test("first turn injects and marks session; second turn short-circuits", async () => {
+        const sessionFile = createSessionFile([
+          { role: "user", content: "Tell me about the architecture" },
+          { role: "assistant", content: "The system uses microservices with Neo4j" },
+        ]);
+
+        const engine = createEngine();
+        await engine.bootstrap({ sessionId: "sess-1", sessionFile });
+
+        const result1 = await engine.assemble({
+          sessionId: "sess-1",
+          messages: [{ role: "user", content: "Hello" }],
+        });
+        expect(result1.systemPromptAddition).toBeDefined();
+
+        // Same session, no lifecycle event, no deictic — should short-circuit
+        const result2 = await engine.assemble({
+          sessionId: "sess-1",
+          messages: Array.from({ length: 5 }, (_, i) => ({ role: i % 2 === 0 ? "user" : "assistant", content: `msg ${i}` })),
+        });
+        expect(result2.systemPromptAddition).toBeUndefined();
+      });
+
+      test("second turn does not call /get-memory or /search", async () => {
+        const sessionFile = createSessionFile([
+          { role: "user", content: "Previous discussion about deployment" },
+          { role: "assistant", content: "Deployment uses Docker containers" },
+        ]);
+
+        const engine = createEngine();
+        await engine.bootstrap({ sessionId: "sess-1", sessionFile });
+
+        // First call — triggers recall
+        await engine.assemble({
+          sessionId: "sess-1",
+          messages: [{ role: "user", content: "Hello" }],
+        });
+
+        // Clear request tracking
+        delete (lastRequest as any)["/get-memory"];
+        delete (lastRequest as any)["/search"];
+
+        // Second call — should short-circuit without server calls
+        await engine.assemble({
+          sessionId: "sess-1",
+          messages: [{ role: "user", content: "Next question" }],
+        });
+
+        expect(lastRequest["/get-memory"]).toBeUndefined();
+        expect(lastRequest["/search"]).toBeUndefined();
+      });
+
+      test("zero facts do not mark session", async () => {
+        mockOverrides.searchFacts = [];
+        mockOverrides.getMemoryFacts = [];
+
+        const engine = createEngine();
+        await engine.bootstrap({ sessionId: "sess-1" });
+
+        // First assemble — no facts returned, session should NOT be marked
+        const result1 = await engine.assemble({
+          sessionId: "sess-1",
+          messages: [{ role: "user", content: "Hello" }],
+        });
+        expect(result1.systemPromptAddition).toBeUndefined();
+
+        // Restore facts and trigger compact to set _lastEvent (messages must be >20 chars)
+        mockOverrides.searchFacts = undefined;
+        mockOverrides.getMemoryFacts = undefined;
+        await engine.compact({
+          sessionId: "sess-1",
+          messages: [
+            { role: "user", content: "Tell me about the deployment pipeline and its stages" },
+            { role: "assistant", content: "The pipeline uses Docker containers with GitHub Actions for CI/CD" },
+          ],
+        });
+
+        // Next assemble should still attempt recall (session was never marked)
+        const result2 = await engine.assemble({
+          sessionId: "sess-1",
+          messages: [{ role: "user", content: "Continue" }],
+        });
+        expect(result2.systemPromptAddition).toBeDefined();
+      });
+
+      test("different sessionId still performs recall", async () => {
+        const sessionFile = createSessionFile([
+          { role: "user", content: "Architecture discussion" },
+          { role: "assistant", content: "Event-driven design with plugins" },
+        ]);
+
+        const engine = createEngine();
+        await engine.bootstrap({ sessionId: "sess-1", sessionFile });
+
+        // Mark sess-1
+        const result1 = await engine.assemble({
+          sessionId: "sess-1",
+          messages: [{ role: "user", content: "Hello" }],
+        });
+        expect(result1.systemPromptAddition).toBeDefined();
+
+        // sess-2 should still get recall (few messages → gap detected)
+        const result2 = await engine.assemble({
+          sessionId: "sess-2",
+          messages: [{ role: "user", content: "Tell me about Alice" }],
+        });
+        expect(result2.systemPromptAddition).toBeDefined();
+      });
+
+      test("compact overrides short-circuit", async () => {
+        const sessionFile = createSessionFile([
+          { role: "user", content: "System design discussion" },
+          { role: "assistant", content: "The system uses event-driven architecture" },
+        ]);
+
+        const engine = createEngine();
+        await engine.bootstrap({ sessionId: "sess-1", sessionFile });
+
+        // First call — marks session
+        const result1 = await engine.assemble({
+          sessionId: "sess-1",
+          messages: [{ role: "user", content: "Hello" }],
+        });
+        expect(result1.systemPromptAddition).toBeDefined();
+
+        // Compact sets _lastEvent = "compact" (messages must be >20 chars)
+        await engine.compact({
+          sessionId: "sess-1",
+          messages: [
+            { role: "user", content: "Tell me about the deployment pipeline and its stages" },
+            { role: "assistant", content: "The pipeline uses Docker containers with GitHub Actions for CI/CD" },
+          ],
+        });
+
+        // Next assemble — compact event overrides the session gate
+        const result2 = await engine.assemble({
+          sessionId: "sess-1",
+          messages: [{ role: "user", content: "Where were we?" }],
+        });
+        expect(result2.systemPromptAddition).toBeDefined();
+      });
+
+      test("deictic reference overrides short-circuit", async () => {
+        const sessionFile = createSessionFile([
+          { role: "user", content: "Discuss the authentication redesign" },
+          { role: "assistant", content: "JWT with refresh tokens for the new auth system" },
+        ]);
+
+        const engine = createEngine();
+        await engine.bootstrap({ sessionId: "sess-1", sessionFile });
+
+        // First call — marks session
+        const result1 = await engine.assemble({
+          sessionId: "sess-1",
+          messages: [{ role: "user", content: "Hello" }],
+        });
+        expect(result1.systemPromptAddition).toBeDefined();
+
+        // Deictic reference should override the session gate
+        const result2 = await engine.assemble({
+          sessionId: "sess-1",
+          messages: Array.from({ length: 5 }, (_, i) => ({
+            role: i % 2 === 0 ? "user" : "assistant",
+            content: i === 4 ? "continue where we left off" : `msg ${i}`,
+          })),
+        });
+        expect(result2.systemPromptAddition).toBeDefined();
+      });
     });
 
     test("autoRecall: false disables recall in assemble but engine still works", async () => {


### PR DESCRIPTION
## Summary

Closes #168

- `assemble()` now skips recall after the first successful Graphiti injection for a given `sessionId`, eliminating per-turn prompt churn and improving prompt-cache reuse
- Lifecycle events (bootstrap, compaction) and deictic references ("continue where we left off") override the gate so recovery still fires when needed
- Sessions with zero recalled facts are not marked, so retry is possible on the next eligible turn

## Changes

- **`context-engine.ts`**: Add `_recalledSessions` Set with session-scoped short-circuit in `assemble()`, explicit clear on `bootstrap()`/`compact()`, and 1000-entry safety cap
- **`test/context-engine.test.ts`**: 6 new tests (inject+mark, no server calls on skip, zero-facts edge case, cross-session isolation, compact override, deictic override) + 1 updated test
- **`CHANGELOG.md`**: Document the new behavior

## Test plan

- [x] All 281 tests pass (`npm test`)
- [x] First turn injects context and marks session
- [x] Second turn short-circuits without calling `/get-memory` or `/search`
- [x] Zero-fact sessions are not incorrectly marked
- [x] Different `sessionId` still performs recall normally
- [x] Compact event overrides the short-circuit
- [x] Deictic reference overrides the short-circuit