### PR TITLE
fix: remove schema defaults to prevent config overwrite on install/update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,14 @@
 # Changelog
+## [0.7.0-beta.5] — 2026-04-01
+
+### Fixed
+
+- **Config overwrite on install/update** (#172): Removed `default` values from
+  `configSchema` in `openclaw.plugin.json` to prevent the installer from
+  overwriting user-customized settings. Runtime behavior is unchanged — the plugin
+  applies identical defaults in code. Added `placeholder` and clarified `help`
+  text in `uiHints` so the Settings UI still communicates default values.
+
 ## [0.7.0-beta.4] — 2026-03-31
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@
 - **Config overwrite on install/update** (#172): Removed `default` values from
   `configSchema` in `openclaw.plugin.json` to prevent the installer from
   overwriting user-customized settings. Runtime behavior is unchanged — the plugin
-  applies identical defaults in code. Added `placeholder` and clarified `help`
-  text in `uiHints` so the Settings UI still communicates default values.
+  applies identical defaults in code (see `index.ts` register fallbacks).
+  Added `placeholder` and clarified `help` text in `uiHints` so the Settings
+  UI still communicates default values.
 
 ## [0.7.0-beta.4] — 2026-03-31
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,18 @@ The `@beta` tag resolves to the latest pre-release at install time. The resolved
 version is locked, but future `openclaw plugins update` runs will pull the newest
 beta. For reproducible deployments, always use an exact version.
 
+### Known issue: config overwrite on install/update
+
+OpenClaw's plugin installer may overwrite your custom config values with schema
+defaults when you run `openclaw plugins install` or `openclaw plugins update`. As
+of v0.7.0-beta.5, this plugin removes schema defaults to mitigate the issue.
+
+If you are on an older plugin version, verify your settings after install/update:
+
+```bash
+openclaw config get plugins.entries.graphiti.config
+```
+
 ## Recommended setup
 
 As of v0.3.0, Graphiti does **not** claim the exclusive memory slot. The recommended

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -10,32 +10,26 @@
     "properties": {
       "url": {
         "type": "string",
-        "default": "http://localhost:8100",
         "description": "Graphiti server URL"
       },
       "groupId": {
         "type": "string",
-        "default": "core",
         "description": "Graph group ID for namespacing"
       },
       "autoRecall": {
         "type": "boolean",
-        "default": false,
         "description": "Inject relevant facts before each conversation turn"
       },
       "autoCapture": {
         "type": "boolean",
-        "default": true,
         "description": "Automatically ingest conversation content into the graph"
       },
       "recallMaxFacts": {
         "type": "number",
-        "default": 10,
         "description": "Max facts to inject on auto-recall"
       },
       "minPromptLength": {
         "type": "number",
-        "default": 10,
         "description": "Minimum prompt length to trigger auto-recall"
       },
       "apiKey": {
@@ -44,18 +38,15 @@
       },
       "autoIndex": {
         "type": "boolean",
-        "default": true,
         "description": "Create index episodes when files are written to memory/"
       },
       "autoIndexExtensions": {
         "type": "array",
         "items": { "type": "string" },
-        "default": [".md", ".txt"],
         "description": "File extensions to index when autoIndex is enabled (include leading dot, e.g. \".md\")"
       },
       "debug": {
         "type": "boolean",
-        "default": true,
         "description": "Enable debug log file"
       },
       "logFile": {
@@ -77,21 +68,23 @@
     },
     "autoRecall": {
       "label": "Auto-Recall",
-      "help": "Inject relevant facts before each conversation"
+      "help": "Inject relevant facts before each conversation (default: off)"
     },
     "autoCapture": {
       "label": "Auto-Capture",
-      "help": "Automatically ingest conversation content into the graph"
+      "help": "Automatically ingest conversation content into the graph (default: on)"
     },
     "recallMaxFacts": {
       "label": "Max Recall Facts",
       "advanced": true,
-      "help": "Maximum number of facts to inject on auto-recall"
+      "placeholder": "10",
+      "help": "Maximum number of facts to inject on auto-recall (default: 10)"
     },
     "minPromptLength": {
       "label": "Min Prompt Length",
       "advanced": true,
-      "help": "Minimum prompt length to trigger auto-recall"
+      "placeholder": "10",
+      "help": "Minimum prompt length to trigger auto-recall (default: 10)"
     },
     "apiKey": {
       "label": "API Key",
@@ -101,7 +94,7 @@
     },
     "autoIndex": {
       "label": "Auto-Index Memory",
-      "help": "Create index episodes in Graphiti when files are written to memory/"
+      "help": "Create index episodes in Graphiti when files are written to memory/ (default: on)"
     },
     "autoIndexExtensions": {
       "label": "Index File Extensions",
@@ -110,7 +103,7 @@
     },
     "debug": {
       "label": "Debug Log",
-      "help": "Write structured debug log for diagnostics (no conversation content)"
+      "help": "Write structured debug log for diagnostics — no conversation content logged (default: on)"
     },
     "logFile": {
       "label": "Debug Log Path",

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -59,12 +59,12 @@
     "url": {
       "label": "Graphiti Server URL",
       "placeholder": "http://localhost:8100",
-      "help": "URL of the Graphiti FastAPI server"
+      "help": "URL of the Graphiti FastAPI server (default: http://localhost:8100)"
     },
     "groupId": {
       "label": "Group ID",
       "placeholder": "core",
-      "help": "Graph namespace for this agent"
+      "help": "Graph namespace for this agent (default: core)"
     },
     "autoRecall": {
       "label": "Auto-Recall",
@@ -99,6 +99,7 @@
     "autoIndexExtensions": {
       "label": "Index File Extensions",
       "advanced": true,
+      "placeholder": ".md, .txt",
       "help": "Only index memory files with these extensions (default: .md, .txt)"
     },
     "debug": {


### PR DESCRIPTION
## Summary

- Removed all `default` values from `configSchema` in `openclaw.plugin.json` to prevent the installer from overwriting user-customized settings during `openclaw plugins install` / `update`
- Runtime behavior is unchanged — the plugin applies identical defaults in code via fallback operators (`??`, `=== true`, `!== false`)
- Added `placeholder` and clarified `help` text in `uiHints` so the Settings UI still communicates default values
- Documented the known issue and workaround in README

Closes #172

## Test plan

- [x] All 284 tests pass (`npx vitest run`)
- [ ] Verify `openclaw.plugin.json` contains no `"default"` keys in `configSchema`
- [ ] Confirm Settings UI still shows placeholder/help values for all config fields
- [ ] Test install/update cycle preserves user config values