### PR TITLE
fix: run afterTurn Graphiti ingestion off path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 # Changelog
+
+## Unreleased
+
+### Fixed
+
+- Make ContextEngine `afterTurn()` ingestion non-blocking by scheduling Graphiti writes in a guarded background drain instead of awaiting them on the reply path.
+- Keep compaction safe by waiting for pending after-turn ingestion before compact ingestion.
+
 ## [0.7.0-beta.5] — 2026-04-01
 
 ### Fixed

--- a/context-engine.ts
+++ b/context-engine.ts
@@ -71,6 +71,13 @@ interface PluginConfig {
   [key: string]: unknown;
 }
 
+type AfterTurnIngestJob = {
+  sessionId: string;
+  texts: string[];
+  event: "after_turn" | "after_turn_sweep";
+  compactionOccurred: boolean;
+};
+
 // ---------------------------------------------------------------------------
 // GraphitiContextEngine
 // ---------------------------------------------------------------------------
@@ -93,6 +100,12 @@ export class GraphitiContextEngine {
   private _sessionId: string | null = null;
   private _threadId: string | null = null;
   private _recalledSessions = new Set<string>();
+
+  /** afterTurn ingestion runs off the reply path. */
+  private _afterTurnQueue: AfterTurnIngestJob[] = [];
+  private _afterTurnDrainScheduled = false;
+  private _afterTurnDrainInFlight = false;
+  private _afterTurnDrainPromise: Promise<void> | null = null;
 
   constructor(
     private client: GraphitiClient,
@@ -377,6 +390,8 @@ export class GraphitiContextEngine {
           return { ok: true, compacted: false, reason: "server-unhealthy" };
         }
 
+        await this.waitForAfterTurnDrain();
+
         const texts = extractTextsFromMessages(params.messages);
         if (texts.length === 0) {
           // No user/assistant text to preserve — safe to signal compaction complete.
@@ -526,14 +541,75 @@ export class GraphitiContextEngine {
 
     const event = compactionOccurred ? "after_turn_sweep" : "after_turn";
 
+    // Auto-compaction truncated the message window — clear the session
+    // recall flag immediately so the next assemble() can recover continuity
+    // without waiting for slow Graphiti extraction/ingest to finish.
+    if (compactionOccurred) {
+      this.signalRecovery(params.sessionId, "compact");
+    }
+
+    this.enqueueAfterTurnIngest({ sessionId: params.sessionId, texts, event, compactionOccurred });
+    this.debugLog.log("ce-afterTurn", { scheduled: true, count: texts.length, sweep: compactionOccurred });
+  }
+
+  private enqueueAfterTurnIngest(job: AfterTurnIngestJob): void {
+    this._afterTurnQueue.push(job);
+    this.scheduleAfterTurnDrain();
+  }
+
+  private scheduleAfterTurnDrain(): void {
+    if (this._afterTurnDrainScheduled || this._afterTurnDrainInFlight) return;
+
+    this._afterTurnDrainScheduled = true;
+    setTimeout(() => {
+      this._afterTurnDrainScheduled = false;
+      this._afterTurnDrainPromise = this.runAfterTurnDrain();
+      void this._afterTurnDrainPromise;
+    }, 0);
+  }
+
+  private async runAfterTurnDrain(): Promise<void> {
+    if (this._afterTurnDrainInFlight) return this._afterTurnDrainPromise ?? Promise.resolve();
+
+    this._afterTurnDrainInFlight = true;
+    try {
+      while (this._afterTurnQueue.length > 0) {
+        const job = this._afterTurnQueue.shift();
+        if (!job) continue;
+        await this.ingestAfterTurnJob(job);
+      }
+    } catch (err) {
+      this.logger?.warn(`graphiti: afterTurn background drain failed: ${String(err)}`);
+      this.debugLog.log("ce-afterTurn", { backgroundError: String(err) });
+    } finally {
+      this._afterTurnDrainInFlight = false;
+      this._afterTurnDrainPromise = null;
+
+      if (this._afterTurnQueue.length > 0) {
+        this.scheduleAfterTurnDrain();
+      }
+    }
+  }
+
+  private async waitForAfterTurnDrain(): Promise<void> {
+    if (this._afterTurnDrainScheduled && !this._afterTurnDrainPromise) {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+
+    if (this._afterTurnDrainPromise) {
+      await this._afterTurnDrainPromise;
+    }
+  }
+
+  private async ingestAfterTurnJob(job: AfterTurnIngestJob): Promise<void> {
     try {
       const start = Date.now();
-      const joined = sanitizeForCapture(texts.join("\n\n"));
+      const joined = sanitizeForCapture(job.texts.join("\n\n"));
       if (!joined) {
         this.debugLog.log("ce-afterTurn", { skipped: true, reason: "sanitized_empty" });
         return;
       }
-      const episode = compactionOccurred
+      const episode = job.compactionOccurred
         ? joined.slice(-12000)   // sweep: keep tail (newest messages)
         : joined.slice(0, 12000);
 
@@ -541,24 +617,17 @@ export class GraphitiContextEngine {
         content: episode,
         role_type: "user",
         role: "conversation",
-        name: buildEpisodeName("turn", { sessionKey: params.sessionId }),
+        name: buildEpisodeName("turn", { sessionKey: job.sessionId }),
         timestamp: new Date().toISOString(),
         source_description: buildProvenance(this.groupId, {
-          event,
-          session_key: params.sessionId,
+          event: job.event,
+          session_key: job.sessionId,
           thread_id: this._threadId ?? undefined,
         }),
       }]);
 
-      this.logger?.info?.(`graphiti: after-turn ingested ${texts.length} messages`);
-      this.debugLog.log("ce-afterTurn", { count: texts.length, sweep: compactionOccurred, ms: Date.now() - start });
-
-      // Auto-compaction truncated the message window — clear the session
-      // recall flag so the next assemble() fires recovery, mirroring the
-      // explicit compact() method.
-      if (compactionOccurred) {
-        this.signalRecovery(params.sessionId, "compact");
-      }
+      this.logger?.info?.(`graphiti: after-turn ingested ${job.texts.length} messages`);
+      this.debugLog.log("ce-afterTurn", { count: job.texts.length, sweep: job.compactionOccurred, ms: Date.now() - start });
     } catch (err) {
       this.logger?.warn(`graphiti: afterTurn failed: ${String(err)}`);
       this.debugLog.log("ce-afterTurn", { error: String(err) });

--- a/test/context-engine.test.ts
+++ b/test/context-engine.test.ts
@@ -16,6 +16,7 @@ import {
   getMockPort,
   mockOverrides,
   lastRequest,
+  requestBodies,
   SAMPLE_EPISODES_WITH_SESSION,
   SAMPLE_FACTS,
 } from "./helpers.js";
@@ -48,6 +49,20 @@ function createSessionFile(dir: string, messages: Array<{ role: string; content:
   ];
   require("node:fs").writeFileSync(filePath, lines.join("\n"));
   return filePath;
+}
+
+async function waitUntil(predicate: () => boolean, timeoutMs = 500): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 1));
+  }
+  throw new Error("Timed out waiting for condition");
+}
+
+async function waitForMessageRequest(timeoutMs = 500): Promise<any> {
+  await waitUntil(() => !!lastRequest["/messages"], timeoutMs);
+  return lastRequest["/messages"] as any;
 }
 
 describe("GraphitiContextEngine", () => {
@@ -235,7 +250,7 @@ describe("GraphitiContextEngine", () => {
         prePromptMessageCount: 2,
       });
 
-      const req = lastRequest["/messages"] as any;
+      const req = await waitForMessageRequest();
       expect(req).toBeDefined();
       expect(req.messages[0].content).toContain("architecture");
       expect(req.messages[0].content).toContain("design patterns");
@@ -255,10 +270,30 @@ describe("GraphitiContextEngine", () => {
         prePromptMessageCount: 1,
       });
 
-      const req = lastRequest["/messages"] as any;
+      const req = await waitForMessageRequest();
       expect(req).toBeDefined();
       expect(req.messages[0].content).toContain("architecture");
       expect(req.messages[0].content).not.toContain("Tool result");
+    });
+
+    test("returns before slow Graphiti ingestion completes", async () => {
+      mockOverrides.ingestDelayMs = 100;
+      const engine = createEngine();
+
+      const start = Date.now();
+      await engine.afterTurn({
+        sessionId: "sess-1",
+        messages: [
+          { role: "user", content: "New question about architecture and design" },
+          { role: "assistant", content: "New answer about architecture and system design" },
+        ],
+        prePromptMessageCount: 0,
+      });
+      const elapsed = Date.now() - start;
+
+      expect(elapsed).toBeLessThan(50);
+      const req = await waitForMessageRequest();
+      expect(req.messages[0].content).toContain("architecture");
     });
 
     test("skips heartbeat turns", async () => {
@@ -272,6 +307,7 @@ describe("GraphitiContextEngine", () => {
         isHeartbeat: true,
       });
 
+      await new Promise((resolve) => setTimeout(resolve, 5));
       expect(lastRequest["/messages"]).toBeUndefined();
     });
 
@@ -316,7 +352,7 @@ describe("GraphitiContextEngine", () => {
         prePromptMessageCount: 10, // pre-compaction count, now only 5 messages remain
       });
 
-      const req = lastRequest["/messages"] as any;
+      const req = await waitForMessageRequest();
       expect(req).toBeDefined();
       // All 5 messages should be considered — 4 are user/assistant with enough text
       expect(req.messages[0].content).toContain("architecture");
@@ -337,7 +373,7 @@ describe("GraphitiContextEngine", () => {
         prePromptMessageCount: 8, // compaction occurred
       });
 
-      const req = lastRequest["/messages"] as any;
+      const req = await waitForMessageRequest();
       expect(req).toBeDefined();
       expect(req.messages[0].source_description).toContain("after_turn_sweep");
     });
@@ -354,7 +390,7 @@ describe("GraphitiContextEngine", () => {
         prePromptMessageCount: 1,
       });
 
-      const req = lastRequest["/messages"] as any;
+      const req = await waitForMessageRequest();
       expect(req).toBeDefined();
       expect(req.messages[0].source_description).toContain('"event":"after_turn"');
       expect(req.messages[0].source_description).not.toContain("after_turn_sweep");
@@ -512,6 +548,36 @@ describe("GraphitiContextEngine", () => {
       const req = lastRequest["/messages"] as any;
       expect(req).toBeDefined();
       expect(req.messages[0].content).toContain("architecture");
+    });
+
+    test("waits for pending afterTurn ingestion before compact ingestion", async () => {
+      mockOverrides.ingestDelayMs = 50;
+      const engine = createEngine();
+
+      await engine.afterTurn({
+        sessionId: "sess-1",
+        messages: [
+          { role: "user", content: "Turn question about project architecture and design" },
+          { role: "assistant", content: "Turn answer about modular architecture patterns" },
+        ],
+        prePromptMessageCount: 0,
+      });
+
+      const result = await engine.compact({
+        sessionId: "sess-1",
+        messages: [
+          { role: "user", content: "Compacted question about deployment process" },
+          { role: "assistant", content: "Compacted answer about release validation" },
+        ],
+      });
+
+      expect(result.ok).toBe(true);
+      expect(result.compacted).toBe(true);
+      expect(requestBodies["/messages"]).toHaveLength(2);
+      const afterTurnReq = requestBodies["/messages"][0] as any;
+      const compactReq = requestBodies["/messages"][1] as any;
+      expect(afterTurnReq.messages[0].source_description).toContain('"event":"after_turn"');
+      expect(compactReq.messages[0].source_description).toContain('"event":"compact"');
     });
 
     test("falls back to bridge when server unhealthy", async () => {
@@ -965,7 +1031,7 @@ describe("GraphitiContextEngine", () => {
         prePromptMessageCount: 10, // trigger sweep
       });
 
-      const req = lastRequest["/messages"] as any;
+      const req = await waitForMessageRequest();
       expect(req).toBeDefined();
       // The tail marker must survive because sweep uses slice(-12000)
       expect(req.messages[0].content).toContain("UNIQUE_TAIL_MARKER");
@@ -1669,6 +1735,7 @@ describe("GraphitiContextEngine", () => {
       });
 
       // Capture should still work even with recall disabled
+      await waitForMessageRequest();
       expect(lastRequest["/messages"]).toBeDefined();
     });
   });
@@ -1953,7 +2020,7 @@ describe("GraphitiContextEngine", () => {
         prePromptMessageCount: 0,
       });
 
-      const req = lastRequest["/messages"] as any;
+      const req = await waitForMessageRequest();
       const prov = JSON.parse(req.messages[0].source_description);
       expect(prov.thread_id).toBe("thread-xyz");
     });

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -107,6 +107,7 @@ export type MockOverrides = {
   getMemoryFacts?: GraphitiFact[];
   ingestStatus?: number;
   ingestBody?: Record<string, unknown>;
+  ingestDelayMs?: number;
   searchStatus?: number;
   searchErrorBody?: string;
   episodes?: any[];
@@ -118,6 +119,7 @@ let port: number;
 
 export let mockOverrides: MockOverrides = {};
 export const lastRequest: Record<string, unknown> = {};
+export const requestBodies: Record<string, unknown[]> = {};
 /** Headers from the most recent request to each path (lowercase keys). */
 export const lastHeaders: Record<string, Record<string, string>> = {};
 
@@ -128,6 +130,7 @@ export function getMockPort(): number {
 export function resetMockState(): void {
   mockOverrides = {};
   for (const key of Object.keys(lastRequest)) delete lastRequest[key];
+  for (const key of Object.keys(requestBodies)) delete requestBodies[key];
   for (const key of Object.keys(lastHeaders)) delete lastHeaders[key];
 }
 
@@ -189,7 +192,12 @@ export function startMockServer(): Promise<void> {
       // POST /messages  (returns 202 like real Graphiti)
       if (req.method === "POST" && url.pathname === "/messages") {
         const body = await readBody(req);
-        lastRequest["/messages"] = JSON.parse(body);
+        const parsed = JSON.parse(body);
+        lastRequest["/messages"] = parsed;
+        (requestBodies["/messages"] ??= []).push(parsed);
+        if (mockOverrides.ingestDelayMs) {
+          await new Promise((resolve) => setTimeout(resolve, mockOverrides.ingestDelayMs));
+        }
         const status = mockOverrides.ingestStatus ?? 202;
         res.writeHead(status, { "Content-Type": "application/json" });
         res.end(


### PR DESCRIPTION
## Summary

Moves ContextEngine `afterTurn()` Graphiti ingestion off the reply path by queueing turn-capture jobs and draining them in a guarded background task.

## Why

Graphiti ingestion can be slow because extraction/write work happens synchronously behind the local Graphiti service. Awaiting that work inside `afterTurn()` can delay OpenClaw replies.

## Changes

- `afterTurn()` now schedules ingestion and returns quickly.
- Adds guarded background drain state to avoid duplicate concurrent drains.
- Logs background/ingest failures without throwing into the turn path.
- `compact()` waits for pending after-turn ingestion before compact ingestion, preserving ordering/data safety.
- Keeps heartbeat skip behavior.
- Adds test coverage for:
  - non-blocking `afterTurn()` with delayed ingest
  - eventual `/messages` ingestion
  - `compact()` waiting for pending after-turn ingestion before compact ingestion

## Validation

- `npm test` → 10 files passed, 286 tests passed
- `npm test -- --run test/context-engine.test.ts` → 114 tests passed
- `npm pack --dry-run` → passed
